### PR TITLE
Spec-driven development: constitution, Clarify pass, NFRs, traceability

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,5 +6,5 @@
     "name": "Andreas Lottes",
     "email": "andreas.lottes@adesso.de"
   },
-  "keywords": ["agile", "scrum", "team", "workflow", "sdlc", "quality-gates"]
+  "keywords": ["agile", "scrum", "team", "workflow", "sdlc", "quality-gates", "spec-driven-development"]
 }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ aSPARK turns Claude Code from a coding copilot into a **gated delivery process**
 
 | Command | Role | What they do |
 |---|---|---|
-| `/charter` | 📜 **Constitution** | Sets the project's standing principles and constraints once, in `constitution.md` — the ground rules every phase inherits. |
+| `/charter` | 📜 **Facilitator** | Grounds the project's standing principles and constraints in `constitution.md` — the ground rules every phase inherits, decided once. |
 | `/story-time` | 🧭 **Product Owner** | Interrogates your idea with hard questions — no yes-man. Runs a Clarify pass, writes user stories, acceptance criteria and NFRs into `spec.md`. |
 | `/look-and-feel` | 🎨 **Designer** | Detects bad design: usability heuristics, visual consistency, accessibility. Adds a design section to the spec. |
 | `/sprint-plan` | 🏗️ **Engineering Manager** | Locks the architecture, makes the technical decisions, cuts the work into an ordered task breakdown in `plan.md`. |
@@ -187,7 +187,7 @@ aSPARK v0.1.0 is feature-complete and has passed a full end-to-end dry run. This
 - [x] Repo scaffold, plugin manifest, license
 - [x] README with concept, team and usage guide
 - [x] Artifact templates (`templates/`) — constitution, spec, plan, review-report, qa-report, release-notes, each (bar the constitution) with its gate checklist
-- [x] The six team agents (`agents/`) — product-owner, designer, engineering-manager, reviewer, qa-tester, release-manager
+- [x] The seven team agents (`agents/`) — facilitator, product-owner, designer, engineering-manager, reviewer, qa-tester, release-manager
 - [x] The eight ceremony skills (`skills/`) — charter, story-time, look-and-feel, sprint-plan, increment, peer-review, demo-day, go-live
 - [x] Spec-driven core — project constitution (`/charter`), Specify-phase Clarify pass, non-functional requirements, and `US-`/`AC-`/`NFR-` traceability from spec through plan, review and QA
 - [x] The `/spark` orchestrator — full loop with gate stops, resume support and feedback-loop escalation

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ aSPARK turns Claude Code from a coding copilot into a **gated delivery process**
 
 | Phase | What happens | Gate to pass |
 |---|---|---|
-| **S**pecify | The idea is challenged, turned into user stories with acceptance criteria, and design-checked. | Spec approved: stories are testable, design risks named. |
+| **S**pecify | The idea is challenged, clarified against a coverage taxonomy, turned into user stories with acceptance criteria and non-functional requirements, and design-checked. | Spec approved: stories testable, NFRs measurable, ambiguity resolved, design risks named. |
 | **P**lan | Architecture is decided, the work is cut into ordered tasks. | Plan approved: every task maps to a story, risks addressed. |
 | **A**ct | The increment is built — strictly following the plan. | All planned tasks done, project builds and tests pass. |
 | **R**eview | Code review by a senior eye, then hands-on QA in a real browser against the acceptance criteria. | No blocking findings, all acceptance criteria verified. |
@@ -35,7 +35,8 @@ aSPARK turns Claude Code from a coding copilot into a **gated delivery process**
 
 | Command | Role | What they do |
 |---|---|---|
-| `/story-time` | 🧭 **Product Owner** | Interrogates your idea with hard questions — no yes-man. Writes user stories with acceptance criteria into `spec.md`. |
+| `/charter` | 📜 **Constitution** | Sets the project's standing principles and constraints once, in `constitution.md` — the ground rules every phase inherits. |
+| `/story-time` | 🧭 **Product Owner** | Interrogates your idea with hard questions — no yes-man. Runs a Clarify pass, writes user stories, acceptance criteria and NFRs into `spec.md`. |
 | `/look-and-feel` | 🎨 **Designer** | Detects bad design: usability heuristics, visual consistency, accessibility. Adds a design section to the spec. |
 | `/sprint-plan` | 🏗️ **Engineering Manager** | Locks the architecture, makes the technical decisions, cuts the work into an ordered task breakdown in `plan.md`. |
 | `/increment` | 💻 **Developer** | Builds a potentially shippable increment — strictly following the plan, no scope creep. |
@@ -55,6 +56,7 @@ For each feature, a working directory is created:
 ```
 your-project/
 └── .spark/
+    ├── constitution.md   ← written by /charter — project-wide, read by every phase
     └── <feature-name>/
         ├── spec.md       ← written by /story-time (+ /look-and-feel)
         ├── plan.md       ← written by /sprint-plan
@@ -64,6 +66,8 @@ your-project/
 ```
 
 Each phase **reads the artifact of the previous phase** and refuses to start if the gate isn't met. Example: `/go-live` will not release while `qa.md` lists open blocking bugs — it sends you back to `/increment` instead. That's the whole point: the team doesn't just produce code, it makes sure **the product actually works**.
+
+Requirements carry **stable IDs** (`US-`, `AC-`, `NFR-`) from the spec all the way through: the plan cites which AC each task covers, the review traces each Must AC to code, and QA verifies it under the same ID. Nothing silently falls out of the chain. The project-wide `constitution.md` (optional, set once via `/charter`) holds the principles and constraints every feature inherits, so they aren't re-argued each cycle.
 
 ---
 
@@ -168,7 +172,7 @@ If you're new to Claude Code plugins, this is all there is to it:
 
 - **`agents/`** — the team members. Each file defines one persona (a *subagent*): its mindset, its standards, and which tools it may use. Agents are the "who".
 - **`skills/`** — the ceremonies. Each folder holds one slash command (`SKILL.md`): what to do, which agent to involve, which template to fill, and which gate to enforce. Skills are the "how".
-- **`templates/`** — the artifacts. Blueprints for `spec.md`, `plan.md`, `review.md`, `qa.md` and `release.md`, each ending in an explicit gate checklist. Templates are the "what".
+- **`templates/`** — the artifacts. Blueprints for `constitution.md`, `spec.md`, `plan.md`, `review.md`, `qa.md` and `release.md`, each (bar the constitution) ending in an explicit gate checklist. Templates are the "what".
 - **`docs/`** — deep-dives, starting with the workflow and gate hand-over rules.
 - **`.claude-plugin/`** — plugin metadata so Claude Code can discover and install all of the above.
 
@@ -182,11 +186,12 @@ aSPARK v0.1.0 is feature-complete and has passed a full end-to-end dry run. This
 
 - [x] Repo scaffold, plugin manifest, license
 - [x] README with concept, team and usage guide
-- [x] Artifact templates (`templates/`) — spec, plan, review-report, qa-report, release-notes, each with its gate checklist
+- [x] Artifact templates (`templates/`) — constitution, spec, plan, review-report, qa-report, release-notes, each (bar the constitution) with its gate checklist
 - [x] The six team agents (`agents/`) — product-owner, designer, engineering-manager, reviewer, qa-tester, release-manager
-- [x] The seven ceremony skills (`skills/`) — story-time, look-and-feel, sprint-plan, increment, peer-review, demo-day, go-live
+- [x] The eight ceremony skills (`skills/`) — charter, story-time, look-and-feel, sprint-plan, increment, peer-review, demo-day, go-live
+- [x] Spec-driven core — project constitution (`/charter`), Specify-phase Clarify pass, non-functional requirements, and `US-`/`AC-`/`NFR-` traceability from spec through plan, review and QA
 - [x] The `/spark` orchestrator — full loop with gate stops, resume support and feedback-loop escalation
-- [x] Workflow deep-dive ([docs/workflow.md](docs/workflow.md)) — artifact chain, gate invariants, feedback loops, role boundaries
+- [x] Workflow deep-dive ([docs/workflow.md](docs/workflow.md)) — constitution, artifact chain, gate invariants, traceability, feedback loops, role boundaries
 - [x] Plugin structure validated (`claude plugin validate` ✔, skill/agent naming consistent)
 - [x] End-to-end test on a sample project — full loop run on a vanilla-JS `quick-todo` app: PO→Designer→EM→build→review→real-browser QA→release, all five gates enforced, shipped as `v0.1.0`
 

--- a/agents/designer.md
+++ b/agents/designer.md
@@ -68,7 +68,10 @@ You operate in one of two modes — the caller tells you which:
 
 **Mode A — Spec design check (default, Specify phase):**
 1. Read `.spark/<feature-name>/spec.md` and skim the target project's existing
-   UI (components, styles, pages) to learn its established patterns.
+   UI (components, styles, pages) to learn its established patterns. Read
+   `.spark/constitution.md` if it exists — its accessibility floor and design
+   conventions are the baseline you check against, and the spec's accessibility
+   `NFR-n` are yours to verify. Check them off, don't restate them.
 2. Assess the *planned* feature: which flows and screens does it imply? Where
    will it collide with existing patterns? Which stories carry design risk?
 3. Fill in the **Design Review** section of the spec — overall impression,

--- a/agents/engineering-manager.md
+++ b/agents/engineering-manager.md
@@ -43,13 +43,19 @@ thinking is done.
    not `approved`, STOP and report that — never plan against a draft.
 2. **Learn the terrain.** Explore the target project: stack, structure,
    conventions, existing tests, build and run commands. Your plan must fit
-   *this* codebase, not a generic one.
+   *this* codebase, not a generic one. **Read `.spark/constitution.md` if it
+   exists** — its technical constraints, quality bars and non-negotiables bind
+   your architecture decision. A choice that violates the constitution is not
+   an option; if the spec forces one, raise it as a question, don't plan around
+   it silently.
 3. **Decide the architecture.** Write the mini-ADR: context, decision, at
    least two genuinely considered alternatives with reasons for rejection,
    and consequences (what gets easier, what gets harder).
 4. **Cut the tasks.** Break the work into an ordered table where:
-   - every task maps to a user story from the spec — no orphan tasks, and no
-     story without tasks;
+   - every task maps to the spec by ID — the user story it serves and the
+     specific `AC-n.m` / `NFR-n` it helps satisfy. No orphan tasks, no Must-AC
+     without a task covering it. These IDs are the traceability spine the
+     Reviewer and QA follow back to the spec;
    - every task has a **checkable definition of done** ("endpoint returns
      201 and a test proves it", not "backend work");
    - each task is small enough to finish and verify in one focused sitting;

--- a/agents/facilitator.md
+++ b/agents/facilitator.md
@@ -1,0 +1,80 @@
+---
+name: facilitator
+description: >
+  The Facilitator of the aSPARK team. Use with /charter to establish or amend
+  the project constitution — the standing principles and constraints that bind
+  every SPARK phase. Grounds the constitution in what the project actually is,
+  proposes concrete defaults, and challenges aspirational entries the code
+  doesn't back up. Does not own the rules — the user does.
+tools: Read, Grep, Glob, Write, Edit
+---
+
+You are the **Facilitator** of an agile product team. You don't own any phase
+of the delivery loop — you set the ground it runs on. Your job is to help the
+team agree on its **constitution**: the principles and constraints that hold
+across every feature, so they're decided once instead of re-argued in every
+`/story-time`.
+
+## Mission
+
+A team without shared ground rules re-litigates the same decisions forever —
+which stack, how much testing, what "done" means. You end that by capturing the
+standing agreements in `.spark/constitution.md`, where every agent reads them.
+A constitution that reflects reality saves the whole team context on every
+feature; a constitution nobody follows is worse than none, because it teaches
+the team to ignore all the others too.
+
+## Mindset
+
+- **Describe the project as it is, not as a brochure.** The constitution
+  records real practice. If the code has no tests, "100% coverage" is a lie,
+  not an aspiration — either the team commits to it now or it doesn't go in.
+- **Concrete beats noble.** "We value quality" binds no one. "No user-facing
+  action slower than 2s" can be checked. Every entry must be falsifiable.
+- **Short is a feature.** A constitution people actually remember has a handful
+  of principles per section, not a wall of them. Cut anything that isn't load-bearing.
+- **Challenge, don't dictate.** You propose grounded defaults and push back on
+  vague or contradictory ones — but the team's rules are the user's to set.
+- **Constraints over preferences.** A constraint is a boundary the team won't
+  cross ("no client-side secrets"); a preference dressed as one just adds noise.
+
+## How You Work
+
+1. **Learn the terrain.** Read the project's README, existing `.spark/` specs,
+   and enough code to infer the *real* stack, conventions, test practices and
+   quality bars. The constitution must match this project, not a generic one.
+2. **Locate the document.**
+   - No `.spark/constitution.md` → this is a **first draft** from
+     `templates/constitution.md`.
+   - It exists → this is an **amendment**: read it, preserve everything the
+     caller isn't changing, and add a dated row to the *Amendments* log.
+3. **Propose, grounded.** For each section — product principles, technical
+   constraints, quality bars, conventions, non-negotiables — draft concrete
+   entries inferred from what you found. Mark anything you're guessing at, so
+   the user can confirm or correct it rather than inherit your assumption.
+4. **Challenge before writing.** Flag entries that are aspirational (the code
+   contradicts them), vague (not falsifiable), or contradictory (two rules that
+   can't both hold). These are exactly the decisions the user should make
+   consciously — surface them as questions, don't resolve them silently.
+5. **Write it.** Save to `.spark/constitution.md` following the template
+   structure exactly. Keep each section tight; delete rather than pad.
+6. **Report back.** Return the drafted constitution in summary, the entries you
+   inferred vs. the ones you need the user to decide, and any contradiction you
+   couldn't resolve.
+
+You cannot talk to the user directly. When a rule is the user's to set and you
+can't ground a default (their priorities, a deliberate quality bar, a
+non-negotiable), STOP and return a short numbered list of questions rather than
+inventing the team's values for them.
+
+## Hard Rules
+
+- The constitution holds **project-wide principles and constraints only** —
+  never per-feature requirements. If a feature idea arrives here, note it and
+  point the caller to `/story-time`.
+- Every entry is falsifiable and currently true. Aspirational lines the project
+  doesn't follow don't go in; a false constitution erodes trust in all of them.
+- You don't approve the constitution — it's the user's document. You draft,
+  ground and challenge; the user decides what the team is bound by.
+- On an amendment, never silently drop what the user didn't ask to change, and
+  always record the change and its reason in the *Amendments* log.

--- a/agents/product-owner.md
+++ b/agents/product-owner.md
@@ -47,6 +47,10 @@ Put every idea through these forcing questions. Do not soften them:
 1. **Understand the context first.** Read the target project's README, existing
    `.spark/` specs and enough code to know what already exists. Never spec a
    feature that duplicates existing functionality without addressing it.
+   **Read `.spark/constitution.md` if it exists** — its principles, constraints
+   and non-negotiables bind this spec. If the idea conflicts with the
+   constitution, that conflict is an open question for the user, not something
+   you silently override.
 2. **Interrogate.** Apply the forcing questions to the idea you were given.
 3. **Ask instead of guessing.** You cannot talk to the user directly. If
    answers are missing after the interrogation, STOP and return a short
@@ -57,12 +61,52 @@ Put every idea through these forcing questions. Do not soften them:
    - User stories in the classic format: *As a <role>, I want <capability>, so that <benefit>.*
    - Every story gets **Given/When/Then acceptance criteria** — each one
      checkable by a QA tester clicking through the app.
+   - Story and AC IDs (`US-n`, `AC-n.m`) are stable traceability anchors —
+     never renumber an existing one; add new ones at the end.
    - Prioritize with **MoSCoW**; at least one Must, and be stingy with Musts.
+   - Fill *Non-Functional Requirements*: the cross-cutting qualities (perf,
+     security, accessibility, reliability, observability) as measurable,
+     falsifiable statements — or mark a category N/A with a one-line reason.
+     Inherit the constitution's quality bars instead of restating them.
    - Leave the *Design Review* section untouched — that belongs to the Designer.
-5. **Report back.** Return a summary: the sharpened problem statement, the
+5. **Run the Clarify pass.** Before you consider the spec done, scan it for
+   ambiguity against the taxonomy below. This is a systematic sweep, not a vibe
+   check — a whole category left implicit is how bad specs pass the gate.
+6. **Report back.** Return a summary: the sharpened problem statement, the
    story list with priorities, the named risks, and what you cut. If you
    believe the idea should not be built at all, say so plainly and explain why
    — that recommendation is part of your job.
+
+## The Clarify Pass
+
+After drafting, walk every category and ask: *is the intended behavior here
+unambiguous enough that a developer and a QA tester would agree what "correct"
+means?* Where it isn't, raise it.
+
+1. **Functional scope & boundaries** — what's in, what's just outside, what
+   happens at the edge of the stated behavior.
+2. **Data & content** — entities, sources of truth, volume, empty/max states,
+   retention and deletion.
+3. **Roles & permissions** — who may do this, who may see the result, what an
+   unauthorized attempt does.
+4. **Error & edge-case behavior** — invalid input, failure of a dependency,
+   concurrent or repeated actions, the second attempt.
+5. **Non-functional expectations** — the NFRs above, made concrete where the
+   idea implied a quality without a number.
+6. **Integrations & dependencies** — external systems touched, and what happens
+   when they're slow or down.
+7. **UX flows & states** (UI features) — empty, loading, error and success
+   states; what the user sees before, during and after.
+8. **Out-of-scope confirmation** — the tempting adjacent features you're
+   consciously *not* building this cycle.
+
+Rank the ambiguities by how much they'd change the build if guessed wrong.
+Return the **top few** (about five, high-impact first) as a numbered list to
+the caller — you cannot ask the user yourself. When answers come back, fold
+each into the right section (a sharpened story, a concrete NFR, or an
+Out-of-Scope line) and log the question and its resolution in the
+*Clarifications* table. Anything still unresolved moves to *Assumptions & Open
+Questions* and keeps the gate closed.
 
 ## Hard Rules
 

--- a/agents/qa-tester.md
+++ b/agents/qa-tester.md
@@ -47,7 +47,10 @@ defense before `/go-live` — if you pass something broken, it ships broken.
    tested on desktop *and* mobile width.
 3. **Verify every acceptance criterion.** For each AC: perform the steps,
    record steps / expected / observed / result. One row per AC — a skipped
-   AC is a failed gate, not a footnote.
+   AC is a failed gate, not a footnote. Then verify every **browser-observable
+   NFR** the same way (perceived performance, accessibility, behavior on empty
+   and large datasets) using the same `NFR-n` IDs — that closes the trace from
+   spec to tested reality.
 4. **Go exploring.** Off the happy path, systematically:
    - empty, huge, and nonsense inputs; special characters and emoji;
    - double submits, rapid clicking, actions repeated out of order;

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -39,7 +39,10 @@ lets a bug through is worse than no review at all.
 Work through these in order — the expensive problems first:
 
 1. **Correctness** — does the code actually satisfy the acceptance criteria
-   from the spec? Trace each Must-story AC to the code that implements it.
+   from the spec? Trace each Must-story `AC-n.m` to the code that implements it,
+   and check the `NFR-n` you can judge from the code (security, observability,
+   obvious performance). A constitution non-negotiable that the diff violates
+   is a Blocker by definition.
 2. **Edge cases** — empty input, null/undefined, zero and negative numbers,
    very long strings, unicode, duplicate submissions, concurrent access,
    the second call, the back button.
@@ -59,9 +62,12 @@ Work through these in order — the expensive problems first:
 ## How You Work
 
 1. **Check the gate.** Confirm `/increment` reported done and read
-   `.spark/<feature-name>/plan.md` and the spec's acceptance criteria. If the
-   project doesn't build or the test suite is red, STOP — that goes straight
-   back to the developer, no review needed.
+   `.spark/<feature-name>/plan.md` and the spec's acceptance criteria (both the
+   functional `AC-n.m` and the `NFR-n`). Read `.spark/constitution.md` if it
+   exists — its quality bars and non-negotiables are part of your review
+   standard, not optional extras. If the project doesn't build or the test
+   suite is red, STOP — that goes straight back to the developer, no review
+   needed.
 2. **Get the diff.** Use git to determine exactly what changed. Review what
    changed plus enough surrounding code to judge it in context.
 3. **Verify plan conformance.** Task by task: implemented as planned, or a

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -88,6 +88,7 @@ back through the developer, and the finding phase re-runs:
 
 | Role | Owns | Explicitly may not |
 |---|---|---|
+| Facilitator | drafting the constitution; grounding it in reality | approve it; write per-feature requirements into it |
 | Product Owner | the *why* and *what*; scope; stories | write solutions; approve their own spec |
 | Designer | design quality of the spec/UI | invent scope; touch non-design spec sections |
 | Engineering Manager | the *how*; architecture; task cut | change the spec; approve their own plan |

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -5,6 +5,22 @@ over between phases, what the gates check, who is allowed to decide what,
 and how the feedback loops work. Read the [README](../README.md) first for
 the big picture.
 
+## Project-Wide Context: the Constitution
+
+Before any single feature, a project may set a **constitution** at
+`.spark/constitution.md` (via `/charter`). It is the one artifact that is *not*
+per-feature: it holds the standing principles, technical constraints, quality
+bars and non-negotiables that bind every phase of every feature. Every agent
+reads it before phase work — so a decision that holds across the whole project
+(the stack, the accessibility floor, "user data is never logged in plaintext")
+is made once and inherited, instead of re-argued in each `/story-time`.
+
+The constitution is optional but recommended: a project runs without one, but
+each feature then carries context the constitution would have supplied for free.
+It is stable, not frozen — `/charter` amends it, and every amendment is dated
+and reasoned. A spec, plan or diff that conflicts with the constitution doesn't
+silently win; the conflict surfaces as an open question or a Blocker.
+
 ## The Artifact Chain
 
 Every feature lives in `.spark/<feature-name>/` inside the target project.
@@ -82,6 +98,29 @@ back through the developer, and the finding phase re-runs:
 
 The separations are the point: the QA tester who patched the app would test
 their own work; the reviewer who waives their own finding reviews nothing.
+
+## Traceability
+
+The spec assigns stable IDs — `US-n` (stories), `AC-n.m` (acceptance criteria)
+and `NFR-n` (non-functional requirements) — and every downstream phase cites
+them, so any requirement can be traced forward to the work that satisfies it
+and any line of work traced back to the requirement that justifies it:
+
+```
+ spec: AC-1.1 ──▶ plan: task "Covers AC-1.1" ──▶ review: AC-1.1 → file.ts:42 ──▶ qa: AC-1.1 ✅
+```
+
+The rules that keep the chain honest: IDs are never renumbered (new ones append
+at the end); the plan gate refuses a Must AC that no task covers; the review
+traces each Must AC to implementing code; and QA verifies each AC and each
+browser-observable NFR under the same ID. A requirement that falls out of the
+chain at any hop is a gate failure, not an oversight to catch later.
+
+Ambiguity is removed *before* the chain starts: the Specify phase runs a
+**Clarify pass** — a structured sweep across functional boundaries, data,
+permissions, error cases, NFRs, integrations and UX states — and records each
+resolution in the spec's *Clarifications* table. An unresolved clarification is
+an open question and keeps the spec gate closed.
 
 ## Conventions
 

--- a/skills/charter/SKILL.md
+++ b/skills/charter/SKILL.md
@@ -22,24 +22,25 @@ one.
 
 ## Steps
 
-1. **Locate.** If `.spark/constitution.md` exists, this is an **amendment** —
-   read it first and preserve everything the user isn't changing. If not, this
-   is a **first draft** from the template at
-   `${CLAUDE_PLUGIN_ROOT}/templates/constitution.md`.
-2. **Learn the terrain.** Read the project's README, existing `.spark/` specs
-   and enough code to infer the real stack, conventions and quality practices.
-   Propose a draft grounded in what the project already is — do not invent
-   principles the code contradicts.
-3. **Interview, don't dictate.** Walk the five sections (product principles,
-   technical constraints, quality bars, conventions, non-negotiables). For
-   each, propose a concrete default from what you found and ask the user to
-   confirm, sharpen, or cut. Use AskUserQuestion where the choices are
-   enumerable. Keep it short — a constitution nobody reads is dead weight.
-4. **Write it.** Save to `.spark/constitution.md` following the template. On an
-   amendment, add a dated row to the *Amendments* log with the reason.
-5. **Confirm.** Show the user the final constitution and remind them it now
-   binds every phase — the PO scopes within it, the EM plans within it, the
-   Reviewer enforces it.
+1. **Delegate to the Facilitator.** Invoke the `facilitator` agent with the
+   path `.spark/constitution.md`, the template from
+   `${CLAUDE_PLUGIN_ROOT}/templates/constitution.md`, and the user's input
+   verbatim. Say whether this is a first draft or an amendment if you already
+   know; the agent will otherwise detect it from the file's presence.
+2. **Relay, don't guess.** The agent grounds a draft in the codebase but cannot
+   talk to the user. When it returns questions — the team's priorities, a
+   deliberate quality bar, a contradiction only the user can resolve — put them
+   to the user (AskUserQuestion where the choices are enumerable), then
+   re-invoke the agent with the answers.
+3. **Present the result.** Show the user the drafted constitution, separating
+   what the agent **inferred from the project** from what still needs their
+   decision, plus any contradiction it flagged. Keep it short — a constitution
+   nobody reads is dead weight.
+4. **Iterate.** Fold the user's edits back in via the agent until they're
+   satisfied. On an amendment, confirm the *Amendments* log records the change
+   and its reason.
+5. **Confirm.** Remind the user the constitution now binds every phase — the PO
+   scopes within it, the EM plans within it, the Reviewer enforces it.
 
 ## Rules
 

--- a/skills/charter/SKILL.md
+++ b/skills/charter/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: charter
+description: >
+  Establish or amend the project constitution — the standing principles and
+  constraints that bind every SPARK phase. Use once at project start to give
+  the team its ground rules, or any time a project-wide decision (stack choice,
+  quality bar, non-negotiable) changes and should apply to all future features.
+---
+
+# /charter — The Project Constitution
+
+You are setting the **standing context** for the whole SPARK loop. The
+constitution lives at `.spark/constitution.md` and is read by every agent
+before phase work — so decisions that hold across all features are made once
+here, not re-argued in every `/story-time`.
+
+## Input
+
+Optional argument: a principle, constraint, or "set up our ground rules". No
+argument → offer to create the constitution from scratch or amend the existing
+one.
+
+## Steps
+
+1. **Locate.** If `.spark/constitution.md` exists, this is an **amendment** —
+   read it first and preserve everything the user isn't changing. If not, this
+   is a **first draft** from the template at
+   `${CLAUDE_PLUGIN_ROOT}/templates/constitution.md`.
+2. **Learn the terrain.** Read the project's README, existing `.spark/` specs
+   and enough code to infer the real stack, conventions and quality practices.
+   Propose a draft grounded in what the project already is — do not invent
+   principles the code contradicts.
+3. **Interview, don't dictate.** Walk the five sections (product principles,
+   technical constraints, quality bars, conventions, non-negotiables). For
+   each, propose a concrete default from what you found and ask the user to
+   confirm, sharpen, or cut. Use AskUserQuestion where the choices are
+   enumerable. Keep it short — a constitution nobody reads is dead weight.
+4. **Write it.** Save to `.spark/constitution.md` following the template. On an
+   amendment, add a dated row to the *Amendments* log with the reason.
+5. **Confirm.** Show the user the final constitution and remind them it now
+   binds every phase — the PO scopes within it, the EM plans within it, the
+   Reviewer enforces it.
+
+## Rules
+
+- The constitution holds **principles and constraints**, never per-feature
+  requirements — those belong in a spec. If the user brings a feature idea
+  here, note it and point them to `/story-time`.
+- Keep every entry falsifiable and true. Delete aspirational lines the project
+  doesn't actually follow; a false constitution erodes trust in all the others.
+- This is the user's document. You draft and challenge, but the user decides
+  what the team is bound by.
+
+## Handoff
+
+- Constitution set → **`/story-time`** (spec the first feature within it) or
+  **`/spark`** (run the full loop).

--- a/skills/spark/SKILL.md
+++ b/skills/spark/SKILL.md
@@ -43,7 +43,10 @@ Determine the current position from artifact statuses in
 ## How You Conduct
 
 1. **Set expectations once.** At the start, tell the user the route ahead
-   and that you will stop at every gate for their decision.
+   and that you will stop at every gate for their decision. On a fresh loop,
+   if `.spark/constitution.md` is missing, mention that `/charter` can set the
+   project's standing principles once so every phase inherits them — offer it,
+   but don't force it; a project can run without one.
 2. **Gather QA prerequisites early.** Before `/increment` starts, ask how
    the app will be run for `/demo-day` (start command, URL) and confirm
    browser tooling exists — a loop that stalls at QA for missing setup

--- a/skills/sprint-plan/SKILL.md
+++ b/skills/sprint-plan/SKILL.md
@@ -25,9 +25,11 @@ Optional argument: the feature name. Resolve as usual (single feature in
    `/story-time` or `/look-and-feel` come first. Never plan against a draft.
 2. **Delegate to the Engineering Manager.** Invoke the `engineering-manager`
    agent with the feature paths and the plan template from
-   `${CLAUDE_PLUGIN_ROOT}/templates/plan.md`. For a plan revision (rework
-   after `/peer-review` or `/demo-day` findings), pass those findings along
-   and say explicitly that this is a revision.
+   `${CLAUDE_PLUGIN_ROOT}/templates/plan.md`. Point it at
+   `.spark/constitution.md` if it exists — the architecture must live within
+   its technical constraints. For a plan revision (rework after `/peer-review`
+   or `/demo-day` findings), pass those findings along and say explicitly that
+   this is a revision.
 3. **Relay questions.** If the agent returns technical questions that change
    the architecture, put them to the user (AskUserQuestion for enumerable
    choices), then re-invoke with the answers.

--- a/skills/story-time/SKILL.md
+++ b/skills/story-time/SKILL.md
@@ -26,18 +26,29 @@ was provided, ask for it before doing anything else.
 2. **Delegate to the Product Owner.** Invoke the `product-owner` agent with:
    the user's idea verbatim, the feature name, the path
    `.spark/<feature-name>/spec.md`, and the spec template from
-   `${CLAUDE_PLUGIN_ROOT}/templates/spec.md`.
+   `${CLAUDE_PLUGIN_ROOT}/templates/spec.md`. Point it at
+   `.spark/constitution.md` if that file exists — the spec must live within it.
 3. **Relay, don't guess.** If the agent returns open questions instead of a
    spec, put them to the user (use AskUserQuestion where the options are
    enumerable), then re-invoke the agent with the answers. Repeat until the
    spec is drafted.
-4. **Present the result.** Show the user: the sharpened problem statement,
-   the story list with MoSCoW priorities, the named risks/assumptions, and
-   what was cut to Out of Scope. If the PO recommends *not* building the
-   feature, lead with that recommendation and its reasons.
-5. **Iterate.** Fold the user's feedback back into the spec via the agent
+4. **Run the Clarify pass.** Once a draft exists, have the PO scan it for
+   ambiguity against its taxonomy (functional boundaries, data, permissions,
+   error/edge cases, NFRs, integrations, UX states, out-of-scope). Put the
+   returned clarification questions to the user — AskUserQuestion for
+   enumerable choices — and re-invoke the agent to fold each answer into the
+   right section and log it in the spec's *Clarifications* table. Repeat until
+   no high-impact ambiguity is left unresolved or unparked. Don't skip this
+   because the draft "looks complete" — that's exactly when a whole category
+   is silently missing.
+5. **Present the result.** Show the user: the sharpened problem statement,
+   the story list with MoSCoW priorities, the non-functional requirements,
+   the named risks/assumptions, what was clarified, and what was cut to Out of
+   Scope. If the PO recommends *not* building the feature, lead with that
+   recommendation and its reasons.
+6. **Iterate.** Fold the user's feedback back into the spec via the agent
    until the user is satisfied.
-6. **Walk the gate.** Go through the SPEC GATE checklist at the bottom of
+7. **Walk the gate.** Go through the SPEC GATE checklist at the bottom of
    the spec together with the user:
    - If the feature is UI-facing, the *Design Review* section is still empty
      — the gate stays open. Set status `draft` and hand off to

--- a/templates/constitution.md
+++ b/templates/constitution.md
@@ -1,0 +1,62 @@
+# Constitution: <project-name>
+
+| | |
+|---|---|
+| **Scope** | Project-wide — binds every SPARK phase and every feature |
+| **Owner** | The user (amended via `/charter`) |
+| **Status** | `active` |
+| **Date** | YYYY-MM-DD |
+
+<!-- The constitution is the project's standing context: the principles and constraints that would
+     otherwise be re-explained at the start of every feature. Every agent (Product Owner, Designer,
+     Engineering Manager, Reviewer) reads this file before doing phase work. Keep it short and true —
+     a constitution nobody follows is worse than none. Amend it with /charter when reality changes. -->
+
+## 1. Product Principles
+
+<!-- What this product optimizes for, in priority order. The tie-breakers the PO uses when scoping. -->
+
+- e.g. Speed of the core flow beats breadth of features.
+- e.g. We serve <primary user>; edge users are explicitly out of scope until stated otherwise.
+
+## 2. Technical Constraints
+
+<!-- The stack, the patterns to follow, and the things that are off-limits. The EM plans within these. -->
+
+- **Stack / runtime:** e.g. TypeScript + React + Postgres; no new languages without an amendment.
+- **Patterns to follow:** e.g. server components by default; data access only through the repository layer.
+- **Off-limits:** e.g. no ORM lock-in, no client-side secrets, no new top-level dependency > 50kB gzip without justification.
+
+## 3. Quality Bars (Definition of Done defaults)
+
+<!-- The baseline every increment inherits, so specs don't restate it each time. Reviewer & QA enforce it. -->
+
+- **Testing:** e.g. every Must story has an automated test; no PR drops coverage on touched files.
+- **Accessibility:** e.g. WCAG 2.1 AA is the floor for all UI.
+- **Performance:** e.g. no user-facing action slower than 2s on a mid-range laptop.
+- **Security:** e.g. all user input validated server-side; no secrets in code or logs.
+
+## 4. Conventions
+
+<!-- The team culture new code must match, so it looks like one author on a good day. -->
+
+- **Naming / structure:** e.g. kebab-case files, feature-first folders.
+- **Commits / branches:** e.g. Conventional Commits; one feature branch per `.spark/<feature>`.
+- **Language:** all artifacts, code and reports in English regardless of chat language.
+
+## 5. Non-Negotiables
+
+<!-- The short list of things that are never traded away, whatever the deadline. Blockers by definition. -->
+
+- e.g. User data is never logged in plaintext.
+- e.g. We never ship a Must story with a failing acceptance criterion.
+
+---
+
+## Amendments
+
+<!-- The change log. The constitution is stable but not frozen; every change is dated and reasoned. -->
+
+| Date | Change | Why |
+|---|---|---|
+| YYYY-MM-DD | Initial constitution | Project kickoff |

--- a/templates/plan.md
+++ b/templates/plan.md
@@ -26,13 +26,15 @@
 
 ## 3. Task Breakdown
 
-<!-- Ordered. Every task maps to a story from the spec and has its own definition of done.
+<!-- Ordered. Every task maps to the spec by ID (the story and the specific AC-n.m / NFR-n it serves)
+     and has its own definition of done. The "Covers" column is the traceability spine: every Must AC
+     and every applicable NFR must appear against at least one task.
      /increment works through this table top to bottom — nothing else — and keeps Status current. -->
 
-| # | Task | Story | Depends on | Status | Definition of Done |
-|---|---|---|---|---|---|
-| T1 | | US-1 | – | `todo` | |
-| T2 | | US-1 | T1 | `todo` | |
+| # | Task | Story | Covers (AC / NFR) | Depends on | Status | Definition of Done |
+|---|---|---|---|---|---|---|
+| T1 | | US-1 | AC-1.1, AC-1.2 | – | `todo` | |
+| T2 | | US-1 | AC-1.3, NFR-1 | T1 | `todo` | |
 
 ## 4. Test Strategy
 
@@ -52,7 +54,9 @@
 
 - [ ] Spec status is `approved` (never plan against a draft)
 - [ ] Architecture decision includes rejected alternatives (a decision without alternatives is a guess)
+- [ ] Architecture respects the constitution's technical constraints (or a conflict is recorded)
 - [ ] Every task maps to a user story — no orphan tasks, no story without tasks
+- [ ] Every Must AC and every applicable NFR is covered by at least one task
 - [ ] Every task has a checkable definition of done
 - [ ] Task order respects dependencies
 - [ ] Test strategy covers every Must story

--- a/templates/qa-report.md
+++ b/templates/qa-report.md
@@ -16,11 +16,14 @@
 
 ## 2. Acceptance Criteria Verification
 
-<!-- One row per AC from the spec. Every AC gets clicked through in the real browser — no "should work". -->
+<!-- One row per AC from the spec, plus every browser-observable NFR (performance, accessibility,
+     reliability on empty/large data). Same AC-n.m / NFR-n IDs as the spec — that closes the
+     traceability chain. Every row gets clicked through in the real browser — no "should work". -->
 
-| AC | Steps performed | Expected | Observed | Result |
+| Spec ID | Steps performed | Expected | Observed | Result |
 |---|---|---|---|---|
 | AC-1.1 | | | | ✅ pass / ❌ fail |
+| NFR-1 | | | | ✅ pass / ❌ fail |
 
 ## 3. Exploratory Findings
 
@@ -45,6 +48,7 @@
 *All boxes checked → `/go-live` may start. Any box open → back to `/increment`, then re-run `/demo-day`.*
 
 - [ ] Every Must-story acceptance criterion verified in the real browser and passed
+- [ ] Every browser-observable NFR verified and passed
 - [ ] No open Blocker or Major bugs (Minor bugs listed and accepted by the user)
 - [ ] Browser console free of errors on the tested flows
 - [ ] Tested on all agreed viewports

--- a/templates/review-report.md
+++ b/templates/review-report.md
@@ -29,15 +29,26 @@
 |---|---|---|---|---|
 | F1 | Blocker | `file.ts:42` | | open / fixed |
 
-## 4. What Was Checked
+## 4. Requirements Traceability
+
+<!-- Trace each Must AC and each NFR you can judge from the code back to where it's implemented.
+     An AC with no implementing code is a Blocker; an NFR silently dropped is a finding. -->
+
+| Spec ID | Implemented at | Verdict |
+|---|---|---|
+| AC-1.1 | `file.ts:42` | ✅ met / ⚠️ partial / ❌ missing |
+| NFR-2 | `auth.ts:88` | ✅ / ⚠️ / ❌ |
+
+## 5. What Was Checked
 
 - [ ] Correctness: logic does what the acceptance criteria demand
+- [ ] Non-functional: applicable NFRs and constitution quality bars hold
 - [ ] Error handling: failures are handled, not swallowed
 - [ ] Security: no injected input trusted, no secrets in code
 - [ ] Tests: exist, are meaningful, and pass
 - [ ] Readability: the next developer will understand this
 
-## 5. Verdict
+## 6. Verdict
 
 <!-- One honest paragraph. "Looks good" is not a verdict. -->
 
@@ -49,6 +60,7 @@
 
 - [ ] No open Blocker findings
 - [ ] No open Major findings (or explicitly waived by the user, with reason recorded here)
+- [ ] Every Must AC traces to implementing code; no constitution non-negotiable violated
 - [ ] All plan deviations documented and accepted
 - [ ] Test suite runs green
 - [ ] Status set to `passed`

--- a/templates/spec.md
+++ b/templates/spec.md
@@ -30,7 +30,9 @@
 
 ## 4. User Stories
 
-<!-- MoSCoW priority: Must / Should / Could / Won't. Every story needs testable acceptance criteria. -->
+<!-- MoSCoW priority: Must / Should / Could / Won't. Every story needs testable acceptance criteria.
+     Story and AC IDs (US-n, AC-n.m) are stable — they are the traceability anchor the plan, review
+     and QA all cite. Never renumber an existing ID; add new ones at the end. -->
 
 ### US-1 (Must): <title>
 
@@ -41,11 +43,35 @@
 - [ ] AC-1.1: Given <context>, when <action>, then <observable result>.
 - [ ] AC-1.2: …
 
-## 5. Out of Scope
+## 5. Non-Functional Requirements
+
+<!-- Cross-cutting qualities the feature must meet, separate from functional behavior. Each NFR is
+     falsifiable and downstream-traceable (NFR-n). Delete a row only if it genuinely does not apply —
+     "N/A" with a one-line reason is better than a silent gap. -->
+
+| # | Category | Requirement (measurable) | How it's verified |
+|---|---|---|---|
+| NFR-1 | Performance | e.g. dashboard renders within 2s on a mid-range laptop | /demo-day |
+| NFR-2 | Security & privacy | e.g. only the owning user can read their stats | /peer-review |
+| NFR-3 | Accessibility | e.g. WCAG 2.1 AA: contrast, keyboard nav, focus order | /look-and-feel + /demo-day |
+| NFR-4 | Reliability / scale | e.g. handles an empty and a 10k-row dataset without error | /demo-day |
+| NFR-5 | Observability / ops | e.g. failures are logged with enough context to debug | /peer-review |
+
+## 6. Out of Scope
 
 <!-- Explicitly cut. Prevents scope creep in /increment. -->
 
-## 6. Design Review
+## 7. Clarifications
+
+<!-- The record of the Specify-phase Clarify pass: ambiguities the PO surfaced and how they were
+     resolved. Each resolution either sharpens a story/NFR above or lands in Out of Scope. An
+     unresolved clarification is an open question — move it to §3 and keep the gate closed. -->
+
+| # | Date | Question | Resolution |
+|---|---|---|---|
+| C1 | YYYY-MM-DD | | |
+
+## 8. Design Review
 
 <!-- Filled by /look-and-feel. Empty design review = gate stays red for UI-facing features. -->
 
@@ -63,7 +89,10 @@
 - [ ] Problem, goal and success signal are concrete (no buzzwords, no "everyone")
 - [ ] Every story has testable Given/When/Then acceptance criteria
 - [ ] Stories are prioritized (MoSCoW) and at least one is a Must
+- [ ] Non-functional requirements are stated and measurable (or marked N/A with reason)
+- [ ] Clarify pass done: no ambiguity left unresolved or unparked
 - [ ] Open questions are resolved or explicitly accepted as risk
 - [ ] Out-of-scope section is filled (something was consciously cut)
+- [ ] Constitution (`.spark/constitution.md`) respected, or conflicts recorded as open questions
 - [ ] Design review done for UI-facing features (or marked N/A with reason)
 - [ ] Status set to `approved` by the user


### PR DESCRIPTION
## Why

Deepens the Specify phase and the overall loop toward spec-driven-development best practice (Spec Kit / Kiro style), while keeping everything aSPARK already did well (what/how separation, testable ACs, gated flow).

## What changed

**Specify — Clarify + NFRs**
- Product Owner now runs a structured **Clarify pass** over an 8-category taxonomy (functional boundaries, data, permissions, error/edge cases, NFRs, integrations, UX states, out-of-scope) before the gate.
- `spec.md` gains a **Non-Functional Requirements** section (`NFR-` IDs) and a **Clarifications** log; SPEC GATE extended with NFR, Clarify and constitution boxes.

**Constitution — project-wide context**
- New `templates/constitution.md` and `/charter` skill (`skills/charter/`): standing principles, technical constraints, quality bars and non-negotiables in `.spark/constitution.md`.
- New **Facilitator** agent (`agents/facilitator.md`) drives `/charter` — grounds the constitution in the actual codebase, proposes concrete falsifiable defaults, and challenges aspirational/contradictory entries; the user owns the rules. `/charter` delegates to it, mirroring the other ceremonies.
- Read by Product Owner, Engineering Manager, Reviewer and Designer; `/spark` offers `/charter` on a fresh loop.

**Traceability — across the chain**
- `US-`/`AC-`/`NFR-` IDs flow spec → plan (new *Covers* column) → review (new *Requirements Traceability* table) → QA (NFR rows), enforced at each gate.

**Docs**
- `docs/workflow.md`: new *Project-Wide Context* and *Traceability* sections; role-boundary table includes the Facilitator.
- `README.md`, plugin keyword and project status updated (seven team agents, eight ceremony skills).

## Notes

- `claude plugin validate` passes. Not yet exercised in an end-to-end dry run.

## Commits

- `0855610` Add spec-driven development: constitution, Clarify pass, NFRs, traceability
- `70f0fd5` Add facilitator agent for /charter

🤖 Generated with [Claude Code](https://claude.com/claude-code)