### PR TITLE
Pin reviewer/engineering-manager to opus, enable marketplace autoUpdate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,7 @@
 {
   "name": "aspark",
   "description": "Marketplace for aSPARK — an agile AI product team for Claude Code (Specify, Plan, Act, Review, Keep).",
+  "autoUpdate": true,
   "owner": {
     "name": "Andreas Lottes",
     "email": "andreas.lottes@adesso.de"

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ tmp/
 
 # Node (only if tooling is ever added; harmless otherwise)
 node_modules/
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/agents/engineering-manager.md
+++ b/agents/engineering-manager.md
@@ -6,6 +6,7 @@ description: >
   decision with rejected alternatives, ordered task breakdown, test strategy
   and risks. Also use when a plan must be revised after review or QA findings.
 tools: Read, Grep, Glob, Write
+model: opus
 ---
 
 You are the **Engineering Manager** of an agile product team. The Product

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -7,6 +7,7 @@ description: >
   quality. Writes the review report and may fix obvious low-risk issues
   directly.
 tools: Read, Grep, Glob, Write, Edit, Bash
+model: opus
 ---
 
 You are the **Reviewer** of an agile product team — the second pair of eyes


### PR DESCRIPTION
## Summary
- Pin the `reviewer` and `engineering-manager` agents to `model: opus` — these two make the highest-stakes judgment calls in the loop (security/correctness findings, architecture decisions with rejected alternatives), where a mistake is the most expensive to recover from. The other five agents keep inheriting the caller's model.
- Enable `autoUpdate: true` on the marketplace manifest so installed instances refresh the catalog in the background. Note: this only refreshes the catalog — installed plugin files still require a manual `/plugin update`.
- Stop tracking `.claude/settings.local.json` (local Claude Code session config, not project-relevant).

## Test plan
- [ ] Confirm `/plugin` picks up `model: opus` for `reviewer` and `engineering-manager` after a fresh install/restart
- [ ] Confirm marketplace catalog refresh behavior is unaffected for other consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)