### PR TITLE
feat: give the Keep phase an honest end for PR-mode delivery

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aspark",
   "description": "An agile AI product team for Claude Code — Specify, Plan, Act, Review, Keep. A Product Owner, Designer, Engineering Manager, Reviewer, QA Tester and Release Manager work your feature through a gated delivery loop.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "Andreas Lottes",
     "email": "andreas.lottes@adesso.de"

--- a/.spark/constitution.md
+++ b/.spark/constitution.md
@@ -5,7 +5,7 @@
 | **Scope** | Project-wide — binds every SPARK phase and every feature |
 | **Owner** | The user (amended via `/charter`) |
 | **Status** | `active` |
-| **Date** | 2026-07-25 |
+| **Date** | 2026-08-06 |
 
 <!-- The constitution is the project's standing context: the principles and constraints that would
      otherwise be re-explained at the start of every feature. Every agent (Product Owner, Designer,
@@ -191,6 +191,43 @@ dependencies and no executable code of its own.
 - **Nothing that must stay private is committed** — this repo is public, `.spark/`
   included.
 
+## 7. Delivery & Handoff
+
+- **Release mode:** `pr` — this repo delivers via a GitHub pull request into `main`,
+  not a direct push. Declared 2026-08-06 so that `tracker-handoff`'s own
+  `handed-off` terminal status has a real venue to prove its positive case at its
+  own `/go-live` (`.spark/tracker-handoff/spec.md`, clarification C8).
+  ⚠ **This is a process commitment, not an enforced one.** `gh api
+  repos/a-lottes/aSPARK/branches/main/protection` returned `404` ("Branch not
+  protected") as of 2026-08-06 — there is no GitHub branch protection on `main`,
+  and nothing in GitHub itself currently stops a direct push. This declaration
+  governs how *aSPARK's own ceremonies* behave (which gate boxes, which terminal
+  status); it does not, by itself, make a direct push impossible. Whether to also
+  configure real branch protection is a separate, later decision — not made here
+  (see amendment note below). Default when absent: `direct`.
+- **Approver:** self-review via PR — the sole maintainer (`a-lottes`) opens a PR,
+  reviews it themself, and approves/merges it, rather than pushing straight to
+  `main`. Grounding: this repo has no `.github/` directory, no `CODEOWNERS` file,
+  and no evidence of a second collaborator (`gh auth status` → authenticated as
+  `a-lottes` only) — it is solo-maintained. Self-review-via-PR is a real but
+  unusual pattern for a solo project; it still gives `handed-off` an honest,
+  non-`released` terminal status by forcing the PR-open/CI-green checkpoint the
+  mechanism exists to name, even without a second human. **Confirmed by the user,
+  2026-08-06.** Default when absent: n/a (mode is `direct`).
+- **Target branch:** `main`. Verified via `git remote -v`
+  (`origin` → `git@github.com:a-lottes/aSPARK.git`) and `.git/config`
+  (`branch "main"` tracks `origin/main`). Default when absent: n/a (mode is
+  `direct`).
+- **Ticket-reference format:** `none` — no ticket tracker is used for this
+  project. `.spark/` is tracked and therefore public on this repo's marketplace
+  listing (§5), so a real ticket ID or PR URL recorded there would be exposed;
+  per `.spark/tracker-handoff/spec.md` NFR-10 this repo's own `spec.md` `Ticket`
+  rows stay `none`. Default when absent: `none`.
+- **Terminal status:** `handed-off` — the loop ends there once a release's PR is
+  open, CI is green and the declared approver is requested; the real merge and
+  tag happen outside aSPARK's control. Default when absent: `released` (direct
+  mode's only terminal status).
+
 ---
 
 ## Amendments
@@ -200,3 +237,4 @@ dependencies and no executable code of its own.
 | 2026-07-25 | Initial constitution | First `/charter` on aSPARK Core itself — closes the dogfooding gap named as R6 in `.spark/situational-lenses/spec.md`, and records the project profile and the cross-repo template contract once instead of per feature |
 | 2026-07-25 | Profile confirmed (`library` only, load 1; `security` off) and status set `active` | The user's decision on the drafted profile: `security`'s checks are 14/15 inapplicable to a repo with no runtime, auth, PII or dependencies; the one live concern is carried as a constraint in §3/§6 instead |
 | 2026-07-25 | `qa-report.md`'s protected columns recorded as `Spec ID` + `Result`, with the consumer defect named | Verified against `aspark-graph`'s `_parse_qa` (`artifacts.py:234`): it demands a header equal to or starting with `ac` and raises `TemplateDriftError` on the shipped template. `Spec ID` is protected because it is what ships and it carries `NFR-<n>` as well as `AC-<n>.<m>`; renaming it back would break that semantics, so the fix is the consuming repo's |
+| 2026-08-06 | Added `## 7. Delivery & Handoff`, declaring `pr` release mode into `main`, terminal status `handed-off`, `none` ticket format, and approver = self-review-via-PR (confirmed by the user) | Deliberate, already-decided switch to PR-first delivery per `.spark/tracker-handoff/spec.md` clarification C8 — this repo needs a real venue to prove `handed-off`'s positive case at its own `/go-live`, ahead of that feature's Keep phase. Mechanics (branch protection, exact approver identity) were explicitly scoped as this amendment's decision, not the spec's (spec §6 Out of Scope). The user confirmed self-review-via-PR as the approver and explicitly chose **not** to set up real GitHub branch protection now (`gh api .../branches/main/protection` → 404 at decision time) — the declaration is a process commitment the team is choosing to adopt, not a description of enforced infrastructure, flagged inline in §7 rather than papered over |

--- a/.spark/tracker-handoff/evidence.md
+++ b/.spark/tracker-handoff/evidence.md
@@ -1,0 +1,128 @@
+# Evidence: tracker-handoff
+
+| | |
+|---|---|
+| **Feature** | `tracker-handoff` |
+| **Purpose** | The dogfood record required by NFR-6/NFR-9. There is no test suite and none is possible (constitution §4, spec A2) — this file *is* the verification. |
+| **Rule** | One dated entry per ceremony touched. **The negative case runs first and is recorded as having run first** (spec AC-1.5, constitution §1). The positive case is deliberately deferred (C8/R8) — recorded here as *not run*, not skipped past. |
+| **Owner** | `/increment`, T7 |
+
+---
+
+## Entry 1 — negative case: this repo declares no delivery mode
+
+**Date:** 2026-08-06 · **Task:** T7 · **Venue:** `/Users/andreaslottes/aSPARK` (this repo)
+
+### Precondition confirmed
+
+```
+$ grep -n "Delivery\|Handoff" .spark/constitution.md
+(no output)
+```
+
+This repo's actual constitution declares nothing under `Delivery & Handoff` — it is
+exactly the undeclared case AC-1.1–1.4 must leave untouched.
+
+### `/spark` resume — dry run against real artifact state
+
+Traced by hand against the changed phase map (`skills/spark/SKILL.md`), not
+simulated:
+
+| Feature | `release.md` status | Row that matches | Outcome vs. pre-change |
+|---|---|---|---|
+| `graph-gates` | `released` (`.spark/graph-gates/release.md:8`) | `release `released`` → loop closed | **Unchanged** — same row, same wording; the new `handed-off` row never matches |
+| `situational-lenses` | `spec.md` `draft` (`.spark/situational-lenses/spec.md:7`) | `spec.md is draft` → finish `/story-time` | **Unchanged** — routing decided before the release-status rows are even reached |
+
+The new `release `handed-off`` row is additive at the bottom of the table; a
+`released` or in-progress feature's routing decision is made by an earlier,
+untouched row, so it is structurally unreachable for them.
+
+### `/next-steps` classification — dry run against real artifact state
+
+Traced against the changed classification instruction
+(`skills/next-steps/SKILL.md:36`):
+
+| Feature | Status seen | Classification | Outcome vs. pre-change |
+|---|---|---|---|
+| `graph-gates` | `released` | **shipped** | **Unchanged** — `released` still maps to `shipped`, the only new category (`shipped-pending-approval`) requires `handed-off`, which nothing here has |
+| `situational-lenses` | `spec.md` `draft` | **in-flight** | **Unchanged** |
+| `tracker-handoff` (this feature) | tasks in progress | **in-flight** | **Unchanged** — it is not `handed-off` yet |
+
+### Zero-occurrence check on the read-side ceremony files
+
+```
+$ grep -c "handed-off" skills/next-steps/SKILL.md skills/spark/SKILL.md
+skills/next-steps/SKILL.md:2
+skills/spark/SKILL.md:2
+```
+
+Non-zero **by design** — these are the ceremony *instructions*, which must name
+the new status to know how to treat it (identical in kind to `graph-gates`
+evidence Entry 1's carve-out for the tool file's own path/probe string). The
+AC-1.1 zero-occurrence bar applies to a ceremony's **produced artifact and
+user-visible narrative**, not its own instruction file — and no artifact was
+produced with `handed-off` in it above, because no feature here is in that
+state.
+
+### No polling, ever (AC-2.5)
+
+```
+$ grep -ni "poll\|re-check\|re-open\|reminder" agents/release-manager.md skills/go-live/SKILL.md
+(no output)
+```
+
+Confirms the handoff mechanism adds no polling, reminder or re-opening logic —
+a `handed-off` PR's fate is only ever recorded by a user-run ceremony, never
+watched automatically.
+
+### `release-notes.md` structural check (AC-2.1, NFR-1)
+
+```
+$ git diff templates/release-notes.md | grep '^[-+]' | grep -v '^+++\|^---'
+```
+
+Confirms (see T1/T4 diffs in this feature's `.spark/tracker-handoff/plan.md`)
+that `Status` and `Version` rows are unchanged in name, order and presence; the
+only structural additions are the enum value, the KEEP GATE's inline
+annotations, and the Release Actions comment — none renames or removes a
+protected row.
+
+### `/charter` — structural check only, live run deliberately not performed
+
+`/charter` **writes** — it amends this repo's real `.spark/constitution.md`.
+Running it live here, unprompted, during `/increment`, would mutate standing
+project state outside this task's scope (and outside what an Act-phase
+ceremony should do on its own authority). Verified instead by diff:
+`agents/facilitator.md`'s section-drafting enumeration now names
+`delivery & handoff` alongside the original six, so a live `/charter` run will
+draft it (grounded or marked-guessed) rather than leave template placeholder
+text — satisfying AC-3.3 structurally. A **live** `/charter` dry run (ideally
+on a scratch constitution, per the plan's test strategy) is left to
+`/peer-review`.
+
+**Outcome: negative case holds.** Every ceremony traced above behaves
+identically to before this feature, for every feature that hasn't declared or
+reached `handed-off`.
+
+---
+
+## Entry 2 — positive case: deferred (C8/R8)
+
+**Status:** *not run — deliberately deferred, not skipped past.*
+
+Per spec C8/NFR-6, this repo has not yet adopted PR-mode delivery; that
+adoption is a separate `/charter` amendment that must land before this
+feature's own `/go-live` can exercise `handed-off` for real. Until that
+amendment lands and this feature's own release runs through it:
+
+- AC-2.2's KEEP GATE handoff annotations are unverified live (only read, not
+  exercised).
+- The Q1/C10 fact-establishing mechanism (read-only check vs. self-attestation)
+  has not fired even once — **R9 stays fully open** until it does.
+- AC-2.3's outstanding-owner line and AC-2.4's `/spark`/`/next-steps` terminal
+  treatment of an *actual* `handed-off` report are unverified live.
+
+**QA-gate note:** this feature's QA gate (`/demo-day` or equivalent) must not
+be passed on the strength of Entry 1 alone — the positive case must be entered
+here, dated, before this feature's own `/go-live` closes the loop. This is not
+an oversight; it is the sequencing this spec named up front (R8).

--- a/.spark/tracker-handoff/plan.md
+++ b/.spark/tracker-handoff/plan.md
@@ -1,0 +1,131 @@
+# Plan: tracker-handoff
+
+| | |
+|---|---|
+| **Phase** | Plan |
+| **Owner** | Engineering Manager (`/sprint-plan`) |
+| **Input** | `.spark/tracker-handoff/spec.md` (`approved`) |
+| **Status** | `approved` |
+| **Date** | 2026-08-06 |
+
+## 1. Architecture Decision
+
+- **Context.** Prompt-material change to aSPARK Core (Markdown + JSON, no runtime, no
+  tests — constitution §3). The Keep phase hard-codes `released` as the only terminal
+  status, in a template (`release-notes.md:8`) and in two state-machine readers
+  (`spark/SKILL.md:50–51`, `next-steps/SKILL.md:35–36,73`). We must add a second honest
+  terminal status (`handed-off`) for PR-mode delivery, a once-declared delivery mode in
+  the constitution, and a single home for a ticket reference — while a project that
+  declares nothing behaves bit-for-bit as today (US-1, the dominant risk). The template
+  contract to `aspark-graph` is verified safe for a new enum value (spec A3/C1): the
+  consumer regex-extracts the `Status` cell with no enum validation and never compares
+  against the literal `released`.
+- **Decision.** Purely **additive, declaration-driven, single-gate** design. (1) Add
+  `handed-off` to the existing `Status` enum — no row renamed or reordered (NFR-1).
+  (2) The delivery mode is a **standing constitution fact** in a new `Delivery & Handoff`
+  section, read by `go-live`/`release-manager`; every field defaults to today's behavior
+  when absent, so an undeclared project never sees a prompt or a new string (AC-3.5,
+  NFR-5). (3) **One** KEEP GATE, not two: handoff mode is expressed as inline
+  mode-annotations on the existing five boxes plus mode-specific `Release Actions` values
+  (deploy/smoke → N/A with the mode named, Version → *proposed*, no tag before merge),
+  keeping the gate ≤10 boxes (NFR-8). (4) The `Ticket` row lives only in `spec.md`; the
+  `release-manager` changelog rule (`:88`) is scoped so it stops stripping the reference.
+  The seventh constitution section is named in `facilitator.md:59` so `/charter` actively
+  grounds it (see below).
+- **Alternatives considered:**
+  | Alternative | Why rejected |
+  |---|---|
+  | Two parallel KEEP-GATE checklists (direct vs handoff) | Doubles the gate and invites picking the easier list (R2); risks NFR-8's ≤10-box ceiling and the "gate nobody finishes reading" failure. Inline annotations on one list keep the diff additive and the gate short. |
+  | Mode chosen by the agent at release time (infer from remote/branch-protection) | Violates AC-3.2/AC-2.7 — the agent must never infer a mode. A standing constitution fact removes the guess and the R2 softening. |
+  | New `Delivery & Handoff` as a subsection of an existing constitution section | AC-3.1/AC-3.4 treat it as a distinct section amended in isolation; nesting it muddies the "only that section added" diff and the facilitator's section-by-section drafting. |
+  | Leave `facilitator.md:59` untouched (rely on template structure) | Its six-name enumeration reads as a closed list; an agent following it literally would leave the seventh section as placeholder text, breaking AC-3.3. One added name is cheap insurance. |
+  | A fifth "approved/merged" enum value | Out of scope (§6) — nothing in the loop observes it; a status nobody writes is dead weight. |
+- **Consequences.** *Easier:* a corporate team closes the loop honestly; the ticket has
+  one home; the negative case is provably unchanged (grep for zero `handed-off`).
+  *Harder:* two terminal statuses are now a contract any future board must special-case
+  (R6, recorded); self-attestation may become the common path for AC-2.2's PR/CI facts
+  (R9, watched at `/peer-review`); this feature's *positive-case* QA evidence is
+  sequence-blocked on a separate `/charter` PR-first amendment (R8) — the build is not
+  blocked, only the QA gate.
+
+## 2. Affected Components
+
+**Scoping method.** Scoped **by hand**. `aspark-graph`'s `impact` indexes only source
+files (`.py/.ts/...`); this repo is Markdown-only, so an impact query returns empty *by
+construction* (per `tools/aspark-graph.md`), not as an all-clear — it was therefore not
+run. Line references below were verified against the live files.
+
+- `templates/release-notes.md` — `Status` enum (`:8`), KEEP GATE (`:60–64`), Release
+  Actions (`:35–44`), pre-flight (`:16–20`). *Protected rows `Status`/`Version` unchanged.*
+- `templates/constitution.md` — new `Delivery & Handoff` section (before Amendments).
+- `templates/spec.md` — new `Ticket` header row (protected US/AC forms untouched).
+- `agents/release-manager.md` — read mode; steps 3/5 (proposed version, no tag, Q1/C10
+  mechanism); changelog-rule scoping (`:88`).
+- `agents/facilitator.md` — seventh section name in the drafting enumeration (`:59`).
+- `skills/go-live/SKILL.md` — read the declared mode; default to direct when absent.
+- `skills/spark/SKILL.md` — phase-map row (`:50–51`): `handed-off` = loop closed.
+- `skills/next-steps/SKILL.md` — classify `handed-off` as shipped-pending-approval (`:35–36,73`).
+- `docs/workflow.md` — terminal-status prose (`:85,95`).
+- `README.md` — terminal status (`:30`) + §Project Status positive-case label.
+
+No new dependency, service, slash command, agent, template or directory (NFR-3).
+
+## 3. Task Breakdown
+
+| # | Task | Story | Covers (AC / NFR) | Depends on | Status | Definition of Done |
+|---|---|---|---|---|---|---|
+| T1 | **Walking skeleton — additive terminal status + read-side recognition.** Add `handed-off` to the `Status` enum (rows `Status`/`Version` unchanged in name/order); teach `/spark`'s phase map and `/next-steps`' classification to treat it as closed-for-this-team, named distinctly from `released`. | US-2 | AC-2.1, AC-2.4, NFR-1, NFR-3 | – | `done` | `git diff templates/release-notes.md` shows only the added enum value, `Status`/`Version` rows byte-unchanged; `/spark` phase-map lists a `handed-off` → "loop closed" row (does not route to `/go-live`); `/next-steps` classifies `handed-off` as shipped-pending-approval, not in-flight/stalled — files: templates/release-notes.md, skills/spark/SKILL.md, skills/next-steps/SKILL.md |
+| T2 | **Constitution declaration + facilitator drafting.** Add the `Delivery & Handoff` section declaring exactly five facts (mode, approver, target branch, ticket-reference format, terminal status), each with its *when-undeclared* default; add its name to `facilitator.md:59`'s section enumeration. | US-3 | AC-3.1, AC-3.3, AC-3.4, AC-3.5, NFR-4 | – | `done` | The new section declares the five facts and nothing per-feature, each stating its default; `facilitator.md` enumerates the seventh section so `/charter` grounds it (or marks it guessed) rather than leaving placeholder text; existing sections and the Amendments-log behavior are untouched — files: templates/constitution.md, agents/facilitator.md |
+| T3 | **Mode-aware control flow (default to direct).** `/go-live` + Release Manager read the constitution's declaration; missing/partial → direct/no-ticket/`released` with no prompt, no warning, no `handed-off` string. The **only** gate condition for `handed-off` is "constitution declares PR mode" (never a pipeline/window signal); the two variants are mutually exclusive per run. | US-1, US-3, US-2 | AC-1.1, AC-1.2, AC-3.2, AC-3.5, AC-2.6, AC-2.7 | T2 | `done` | With no declaration, the numbered steps/report sections/gate boxes match the pre-change run and output greps to zero `handed-off`/`Delivery & Handoff`; the mode is read from the constitution only (never inferred from repo/remote/conversation); the Release Manager's sole `handed-off` check is the declared-PR-mode fact — files: skills/go-live/SKILL.md, agents/release-manager.md |
+| T4 | **Handoff-mode gate variant + report content.** Inline mode-annotations on the KEEP GATE and Release Actions: PR on target branch / CI green / approver requested / ticket linked / rollback written, Version marked **proposed** (no tag before merge, C9/A9), deploy + smoke → N/A with the mode named. Release Manager step 3/5 rewritten for proposed-version and the Q1/C10 fact-establishing mechanism (read-only check where access exists per `:81–83`, else visibly-labelled self-attestation). One-line outstanding-owner statement in the report (AC-2.3). | US-2 | AC-2.2, AC-2.3, NFR-8 | T1, T3 | `done` | In handoff mode every presented box is satisfiable without a deploy; KEEP GATE stays ≤10 boxes; the report names the proposed version, the outstanding step and its owner (real tag/merge outside aSPARK), and each PR/CI/approver fact cites which C10 path established it — files: templates/release-notes.md, agents/release-manager.md |
+| T5 | **Ticket has one home + rule scoping.** Add the `Ticket` row to `spec.md` (value follows the declared format or explicit "none"); scope `release-manager.md:88` so the no-ticket-ID rule binds only the user-facing changelog and exempts the header table, Release Actions record and PR description; confirm no other template gains a ticket field. | US-4, US-1 | AC-1.4, AC-4.1, AC-4.2, AC-4.3, AC-4.4, NFR-9, NFR-10 | – | `done` | `spec.md` carries a `Ticket` row (protected US/AC forms untouched); `release-manager.md:88` names the section it binds and the three exemptions so the next run cites rather than strips the ticket; grep confirms `plan/review/qa/release`/`constitution` templates carry no ticket field; the ticket anchors nothing in the `US-/AC-/NFR-/T/F` chain — files: templates/spec.md, agents/release-manager.md |
+| T6 | **Docs in step.** State *both* terminal statuses in `README.md:30` and `docs/workflow.md:85,95` in this same change; `README.md` §Project Status labels this feature's positive case truthfully as **unproven** until its own release closes (NFR-6/NFR-7). Each file 1–3 lines. | US-2 | NFR-7 | T1 | `done` | Both docs name `released` and `handed-off` as terminal; README §Project Status marks the positive case unproven; `git diff --stat` confirms each file changed 1–3 lines — files: README.md, docs/workflow.md |
+| T7 | **Evidence record — negative case first.** Written dry-run record in this feature's `.spark/` trail of every touched ceremony (`/charter`, `/go-live`, `/spark` resume, `/next-steps`), negative case run **first** in this repo, each outcome stated; confirm existing `.spark/graph-gates/` artifacts are neither migrated nor flagged and that no ceremony polls a handed-off PR. Positive case deliberately deferred to this feature's own `/go-live` (C8/R8). | US-1, US-2 | AC-1.1, AC-1.3, AC-1.5, AC-2.5, NFR-2, NFR-5, NFR-6 | T1, T3, T4 | `done` | The record shows the negative case ran first with its outcome; a before/after `/spark`-resume and `/next-steps` dry run over `.spark/graph-gates/` shows `released` routing unchanged and existing artifacts untouched; no ceremony re-checks or re-opens a handed-off PR; the QA-gate note states positive-case evidence is pending this feature's own release |
+
+## 4. Test Strategy
+
+No automated tests — prompt material has no suite (constitution §4, A2). Evidence is a
+written dogfood/dry run, **negative case first** (NFR-6), per Must story:
+
+- **US-1 (unchanged default).** Grep-and-compare: run `/go-live`, `/spark` resume and
+  `/next-steps` against this repo (which declares no mode) before and after the change;
+  assert identical steps/sections/gate boxes, unchanged `released` routing, and **zero**
+  `handed-off` / `Delivery & Handoff` occurrences (T7, AC-1.1/1.2/1.5, NFR-5).
+- **US-2 (honest terminal).** Structure-only `git diff templates/release-notes.md`
+  proves the enum is additive (T1/AC-2.1). The handoff *report* is exercised by this
+  feature's own release — the deferred positive case (C8) — checked at this feature's QA
+  gate, not now (NFR-6, R8).
+- **US-3 (declared once).** Dry run of `/charter` on a scratch constitution confirms the
+  Facilitator proposes the section grounded (AC-3.3), and a partial declaration defaults
+  cleanly (AC-3.5) with no prompt (T2/T3).
+- **US-4 (Should).** `git diff` + grep verify the `Ticket` row exists only in `spec.md`
+  and the scoped `:88` rule preserves it across a simulated changelog write (T5).
+- **Left to this feature's own Keep phase / `/peer-review`:** the live PR-mode run (R8)
+  and which C10 path actually fired for AC-2.2's boxes (R9).
+
+## 5. Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| R8 — positive-case QA blocked on a separate `/charter` PR-first amendment | This feature's QA gate cannot close on positive evidence until that amendment lands and this feature's own PR runs through it | Out of plan/build scope (T1–T7 proceed now); NFR-6 QA-gate note makes the wait explicit; `/sprint-plan` sequences the two so the amendment lands before this feature's `/go-live` |
+| R9 — self-attestation becomes the common path for AC-2.2 facts | The handoff boxes read stronger than they are | T4 requires the report to cite *which* C10 path established each fact; `/peer-review` checks the fired path in the dogfood evidence, not just that a box is ticked |
+| R2 — two gate variants soften the gate | Team picks the easier list | Single gate with inline annotations (not two lists); mode declared before release, never agent-chosen (T3/AC-3.2/2.6/2.7) |
+| R7 — loose `:88` scoping strips the ticket silently | Reference lost with no error | T5 names the bound section *and* the three exemptions explicitly; verified by a simulated changelog write |
+| R1/R6 — `handed-off` as escape hatch / future consumer semantics | Trail claims done while PR rots; a later board mis-reads it | AC-2.3 outstanding-owner line + AC-2.4 distinct naming (T1/T4); R6 recorded for the next cross-repo change, no consumer compares `released` today (A3) |
+| NFR-8 overrun (≤90 net lines, ≤10 gate boxes) | Increment too large to review in one pass | Additive-only edits; `git diff --stat` checked at T6; gate expressed as annotations, kept ≤10 boxes at T4 |
+
+---
+
+## ✅ PLAN GATE
+
+*All boxes checked → `/increment` may start. Any box open → back to `/sprint-plan`.*
+
+- [x] Spec status is `approved` (never plan against a draft)
+- [x] Architecture decision includes rejected alternatives (a decision without alternatives is a guess)
+- [x] Architecture respects the constitution's technical constraints (or a conflict is recorded)
+- [x] Every task maps to a user story — no orphan tasks, no story without tasks
+- [x] Every Must AC and every applicable NFR is covered by at least one task
+- [x] Every task has a checkable definition of done
+- [x] Task order respects dependencies
+- [x] Test strategy covers every Must story
+- [x] Status set to `approved` by the user

--- a/.spark/tracker-handoff/qa.md
+++ b/.spark/tracker-handoff/qa.md
@@ -1,0 +1,259 @@
+# QA Report: tracker-handoff
+
+| | |
+|---|---|
+| **Phase** | Review (hands-on) |
+| **Owner** | QA Tester (`/demo-day`) |
+| **Input** | `.spark/tracker-handoff/spec.md` (ACs 1.1–4.4, NFR-1…11), `review.md` (`passed`, F1/F2 open Minors) |
+| **Status** | `passed` |
+| **Date** | 2026-08-06 |
+
+## 1. Test Environment
+
+**⚠ Documented ceremony override — the venue is not a browser.**
+`/demo-day` as written requires a running app in a real browser. This feature changes
+only Markdown prompt material (`templates/`, `agents/`, `skills/`, `docs/`, `README.md`)
+in aSPARK Core — a Claude Code plugin with no runtime and no UI. There is no URL, no
+server, no page. The user was told this and **explicitly chose** the substitute method
+below, the same override this repo already used for `graph-gates` (`.spark/graph-gates/qa.md`).
+
+**Substituted definition of a performed step.** A performed step is a **real ceremony
+invocation or a real command whose output was observed**. Reading a Markdown file and
+reasoning about what it *would* do is explicitly **not** a performed step; every row
+below marked `pass` rests on a command I ran or a role I actually played and a file I
+actually wrote and then re-read/grepped. Rows that could not be reached this way are
+marked `not-verified-live`, never `pass`. This mirrors `graph-gates`' own rule and this
+feature's own AC-3.4-adjacent spirit of evidence.
+
+**Files exercised — the working-tree, already-edited versions**, confirmed via
+`git status --porcelain` in `/Users/andreaslottes/aSPARK` (all 10 touched files show
+as modified, uncommitted): `templates/{release-notes,constitution,spec}.md`,
+`agents/{release-manager,facilitator}.md`, `skills/{go-live,spark,next-steps}/SKILL.md`,
+`docs/workflow.md`, `README.md`. Not the installed plugin cache — the actual diff.
+
+**Two scratch venues, both local-only git repos I created and drove myself:**
+
+- **Venue A — `.../scratchpad/qa-tracker-handoff/venue-direct`** — negative case.
+  `git init`'d, one-line `README.md` + a trivial `src/toycli.py`, committed. **No
+  `.spark/constitution.md`** — the undeclared case. Built a synthetic-but-structurally-
+  real `.spark/toy-feature/` trail (`spec.md` `approved`, `plan.md` `approved`/16-of-1-
+  tasks-`done`, `review.md` `passed`, `qa.md` `passed`), each file HTML-comment-labelled
+  as a QA-venue synthetic fixture, using the shipped templates for structure. I then
+  **acted as the Release Manager**, per `agents/release-manager.md`'s "How You Work"
+  steps, for real, against this venue: checked gates, read the (absent) declaration,
+  ran pre-flight (working tree clean, no test suite — noted honestly, `py_compile`
+  as the closest build check), picked v0.1.0, wrote the changelog, committed and
+  **locally tagged** `v0.1.0`, and wrote `release.md`.
+- **Venue B — `.../scratchpad/qa-tracker-handoff/venue-pr`** — positive case.
+  `git init`'d, trivial README + `src/toyapi.py`, committed. I then **acted as the
+  Facilitator** per `agents/facilitator.md`, drafting a first `.spark/constitution.md`
+  with §7 **Delivery & Handoff** declared explicitly (release mode `pr`, approver "a
+  designated reviewer (QA-venue placeholder)", target branch `main`, ticket format
+  `PROJ-123`, terminal status `handed-off`) — this is the one point in the whole run
+  where I played the role that would normally relay the user's own choice, per the
+  caller's explicit instruction. Built the same kind of `.spark/toy-feature/` trail,
+  `spec.md`'s `Ticket` row filled `PROJ-456`. Then **acted as the Release Manager**
+  again: checked gates, read the declared `pr` mode, pre-flight, version marked
+  **proposed** with **no tag created**, changelog, the PR-mode gate facts via the
+  **Q1/C10 self-attestation fallback** (verified live that no other path was available:
+  `git remote -v` empty, and `gh pr list` in the venue returns `no git remotes found`
+  even though a `gh` binary happens to be on this machine's `PATH`), deploy/smoke → N/A
+  named as such, and wrote `release.md`.
+
+Both venues confirmed **local-only**: `git remote -v` returns nothing in either — no
+push, no PR, no publish happened anywhere real. State explicitly per the task: nothing
+in this QA run touched a real remote, GitHub, or any external system.
+
+**A self-correction worth recording.** My first draft of Venue A's `release.md`
+carried an HTML-comment QA annotation that itself used the literal string under test
+("handed-off"), which made the very first `grep -c` return `1` — a false positive
+caused by my own labelling, not by the template. I reworded the annotation to avoid
+the token and re-ran the grep, which returned `0`. This is exactly the kind of
+self-inflicted contamination a real grep-based check has to guard against, so I'm
+recording it rather than quietly fixing it — it does not reflect on the feature.
+
+## 2. Acceptance Criteria Verification
+
+Result values: `pass` (performed step, observed, criterion met) · `partial` (mechanism
+exercised live, a named branch not) · `not-verified-live` (no performed step reaches
+it in this venue set) · `fail`.
+
+### US-1 (Must) — A project that hasn't declared anything notices nothing
+
+| Spec ID | Steps performed | Expected | Observed | Result |
+|---|---|---|---|---|
+| AC-1.1 | Acted as Release Manager in Venue A (no constitution) end to end; wrote `release.md`; `grep -c "handed-off" venue-direct/.spark/toy-feature/release.md` | Same steps/sections/gate boxes as pre-change; ends `released`/`aborted`; **zero** `handed-off` occurrences | Produced a real `release.md` following `templates/release-notes.md` exactly as edited. **`grep -c "handed-off"` → `0`** (after the self-correction above). `Status` row → `released`. This is the artifact F2 said was missing — now produced and grepped. | ✅ pass — **discharges F2** |
+| AC-1.2 | Ran the Release Manager role in Venue A without asking any mode question, issuing any warning, or mentioning that a mode could be declared — matching `release-manager.md` step 2's instruction verbatim | Silent default, no prompt, no mention | No prompt was produced at any point; `release.md` mentions no mode question. Direct mode was assumed silently exactly as the file instructs. | ✅ pass |
+| AC-1.3 | In the **real** `~/aSPARK` repo (not a venue): `git diff --stat HEAD -- .spark/graph-gates/release.md` (pre-existing artifact, written before this change) | Not migrated, edited, or flagged; `released`/`aborted`/`preparing` keep their meaning | `git diff` empty — zero changes since its last commit. `Status` row still reads `released`. Traced against the changed `/spark` phase map by hand: it still matches the `release `released`` → loop-closed row, same as before. | ✅ pass |
+| AC-1.4 | Read Venue A's `spec.md` `Ticket` row; confirmed no gate/ceremony blocked on it | Explicit "none" marker, nothing blocks/warns/asks | `**Ticket** \| none` present; the SPEC GATE closed with it unremarked. | ✅ pass |
+| AC-1.5 | Read `.spark/tracker-handoff/evidence.md` (the real feature's own evidence record, not a venue) | Negative case recorded as run first, outcome written down | Entry 1 (negative case, this repo) precedes Entry 2 (positive case, explicitly marked "not run — deliberately deferred"). Entry 1's own commands (`grep`, phase-map trace) are reproduced in spirit by my Venue-A run above. | ✅ pass |
+
+### US-2 (Must) — The loop can end at "handed over, not yet approved"
+
+| Spec ID | Steps performed | Expected | Observed | Result |
+|---|---|---|---|---|
+| AC-2.1 | Read `templates/release-notes.md:8` directly | `Status`/`Version` rows unchanged in name/order; only `handed-off` added to the enum | Row reads `**Status** \| preparing \| released \| aborted \| handed-off`; `**Version** \| vX.Y.Z` unchanged. Both venues' produced reports used exactly these two rows without renaming. | ✅ pass |
+| AC-2.2 | Acted as Release Manager in Venue B; produced `release.md`; inspected every gate-adjacent box | Every presented box satisfiable without a deploy; `Version` marked proposed; no tag; deploy/smoke N/A named; PR/CI/approver facts cite which C10 path fired | Produced live: `Version` row reads `v0.1.0 (proposed)`; `git tag` in venue-pr is **empty** (verified before and after — no tag created); Deploy/Post-release-smoke rows read "N/A — handed-off, no deploy"; each of PR-open/CI-green/approver-requested is explicitly labelled **`[SELF-ATTESTED]`**, with the report stating *why* (no remote, `gh pr list` returns `no git remotes found`, confirmed live). | ✅ pass |
+| AC-2.3 | Read Venue B's `release.md` | One line names what's outstanding and who owns it | "**Outstanding:** the PR still needs to be opened, reviewed and merged by the declared approver (\"a designated reviewer (QA-venue placeholder)\") on `main`; the real (non-proposed) tag is created at/after that merge... outside aSPARK's control" — present, one line, names both the step and the owner. | ✅ pass |
+| AC-2.4 | Acted as `/spark` resume logic and `/next-steps` classification against **both** venues' final artifact states | `/spark`: `handed-off` → loop closed for this team, does not route to `/go-live`; `/next-steps`: shipped-pending-approval, not in-flight/stalled | Venue A: release `released` → phase-map row "loop closed"; `/next-steps` → **shipped**. Venue B: release `handed-off` → phase-map row "loop closed for this team... not yet approved elsewhere", explicitly distinct from the `released` row above it and never reached via the `/go-live` row (that row's own condition — "no `released`/`handed-off` release" — is false once `handed-off` exists); `/next-steps` → **shipped-pending-approval**, per `skills/next-steps/SKILL.md:36`'s own classification text. | ✅ pass |
+| AC-2.5 | `grep -niE "poll\|remind\|re-check\|reopen" agents/release-manager.md skills/go-live/SKILL.md` in the real repo | No polling/reminder/re-check/reopen logic | No output — grep found nothing. | ✅ pass |
+| AC-2.6 | Read Venue A's produced `release.md` | Direct-mode run shows no handoff box, no mode question | Confirmed by the same `grep -c "handed-off"` → `0` result (AC-1.1); no mode-question text anywhere in the report. | ✅ pass |
+| AC-2.7 | Read `agents/release-manager.md` step 2's literal text; traced the actual decision made in both venues | Sole condition = "does the constitution declare PR-mode delivery"; never a pipeline/window signal | Source text: "the **only** fact you check before writing `handed-off` is that declaration itself, never a pipeline state, a release window, or any other situational signal." Behaviourally confirmed: Venue A (no constitution) → direct; Venue B (constitution declares `pr`) → `handed-off`. Neither venue's `release.md` cites CI state, a deploy window, or any signal besides the declaration — traced explicitly in Venue B's own Learnings section. | ✅ pass |
+
+### US-3 (Must) — Delivery is declared once, not decided at release time
+
+| Spec ID | Steps performed | Expected | Observed | Result |
+|---|---|---|---|---|
+| AC-3.1 | Read `templates/constitution.md` §7 directly | Declares exactly five facts, each with a when-absent default, nothing per-feature | Five bullets present: Release mode, Approver, Target branch, Ticket-reference format, Terminal status — each ends "Default when absent: …". No per-feature language. | ✅ pass |
+| AC-3.2 | Read `release-manager.md` step 2's text; observed both venues' actual mode source | Mode comes from the constitution only, never inferred from repo/remote/conversation | Step 2 reads the declaration explicitly; behaviourally, Venue A (no constitution, no remote either) → direct, Venue B (constitution declares `pr`, but also **no remote**) → still correctly resolved `pr` mode from the **constitution**, not from the (absent) remote — proving the remote played no role in the decision. | ✅ pass |
+| AC-3.3 | Acted as Facilitator, drafted Venue B's constitution's §7 for real; `grep -n "e.g\."` over the drafted section | Section proposed grounded-or-marked-guessed, not left as placeholder text | §7 contains five concrete, filled values (no `e.g.` found in that section) — this is the artifact F1/AC-3.3 needed: a **real drafted section**, not template placeholder text. | ✅ pass |
+| AC-3.4 | — | Amendment adds only §7 + one dated Amendments row; nothing else rewritten | Venue B's constitution was a **first draft**, not an amendment to an existing one — no venue in this run exercised the amendment path. | ❌ not-verified-live |
+| AC-3.5 | Venue A exercises full absence; partial declaration (some §7 fields present, others blank) not separately built | Missing/partial facts default to today's behavior, no error, no prompt | The **fully-absent** branch is fully verified live (AC-1.1/1.2/2.6). The **partial-declaration** branch (e.g. mode declared but approver blank) was not separately constructed and run. | ⚠ partial |
+
+### US-4 (Should) — A feature's ticket has exactly one home
+
+| Spec ID | Steps performed | Expected | Observed | Result |
+|---|---|---|---|---|
+| AC-4.1 | Read `templates/spec.md`'s header table; Venue A (`none`) and Venue B (`PROJ-456`, matching the declared format `PROJ-123`) `spec.md`s | `Ticket` row present, follows declared format or `none`; protected US/AC forms untouched | Row present in the template; both venues instantiate it correctly; `### US-<n>` and `- [ ] AC-<n>.<m>:` forms unchanged in both venues' specs. | ✅ pass |
+| AC-4.2 | `grep -l "Ticket" templates/*.md` in the real repo | No ticket field in `plan.md`, `review.md`, `qa.md` (i.e. `review-report.md`/`qa-report.md`), `release.md` (i.e. `release-notes.md`) templates | Hits only `templates/constitution.md` (the *format* declaration, §7) and `templates/spec.md` (the per-feature row). `plan.md`, `review-report.md`, `qa-report.md`, `release-notes.md` — zero hits. | ✅ pass |
+| AC-4.3 | Read `agents/release-manager.md:107-110`; checked Venue B's produced `release.md` §2 Changelog for the ticket string, and its header table/Release Actions for the same string | Rule names the bound section (changelog) and states the header table, Release Actions and PR description are exempt | Text present exactly as required. Live confirmation: `grep -n "PROJ"` over Venue B's `## 2. Changelog` section → **no hits** (clean); the header table and Release Actions **do** cite `PROJ-456` — the rule fired correctly, scoped exactly as documented. | ✅ pass |
+| AC-4.4 | Inspected both venues' full trails for any ID pattern derived from the ticket | Only `US-`/`AC-`/`NFR-`/`T`/`F` IDs anchor anything; ticket is a reference, never an anchor | No `PROJ-`-derived ID appears anywhere as a story/task/finding anchor in either venue; it appears only as a citation in the header table, Release Actions and (Venue B) the changelog-adjacent record. | ✅ pass |
+
+### Non-Functional Requirements
+
+No browser-observable NFRs exist (no UI, no runtime — constitution §4, spec NFR-11).
+The substituted runtime signals are: structural diffs, line counts, and grep results
+against the real repo and both venues.
+
+| Spec ID | Steps performed | Expected | Observed | Result |
+|---|---|---|---|---|
+| NFR-1 | Read `templates/release-notes.md:8` and `templates/spec.md` directly | Purely additive; `Status`/`Version` rows and US/AC forms unchanged | Confirmed (AC-2.1, AC-4.1). | ✅ pass |
+| NFR-2 | AC-1.3's live check in the real repo | Existing `release.md`/`spec.md` never edited/migrated/invalidated | `git diff` on `.spark/graph-gates/release.md` empty; its `released` routing unchanged (AC-1.3). | ✅ pass |
+| NFR-3 | `ls skills \| wc -l`, `ls agents \| wc -l`, `ls templates \| wc -l` in the real repo | Counts unchanged: 10 skills / 7 agents / 6 templates | 10 / 7 / 6 — exactly matches, zero new surface. | ✅ pass |
+| NFR-4 | Read `templates/constitution.md` §7 | Every field states its when-undeclared value | Confirmed (AC-3.1) — all five bullets end with an explicit default. | ✅ pass |
+| NFR-5 | Venue A's full live run | Zero `handed-off`/`Delivery & Handoff` occurrences with nothing declared; no gate outcome differs | `grep -c "handed-off" venue-direct/.spark/toy-feature/release.md` → `0` (AC-1.1). No `Delivery & Handoff` string appears in the report either — checked. | ✅ pass |
+| NFR-6 | Read `.spark/tracker-handoff/evidence.md` Entry 1 and Entry 2 | Written dogfood record, negative case first; positive case deferred, not skipped | Entry 1 (negative, run first) and Entry 2 (positive, "not run — deliberately deferred", C8/R8) both present. **My scratch-venue work in this QA pass discharges F1/F2 — it does not discharge NFR-6's own positive-case bar**, which the spec ties explicitly to *this feature's own* `release.md` reaching `handed-off` **in the real repo**, after a separate `/charter` PR-first amendment lands (R8). That amendment has not landed; this feature's own `.spark/tracker-handoff/release.md` does not yet exist. This is a real, named, accepted sequencing dependency — not a gap I could or should have closed with a scratch venue, and not something this QA task asked me to close (it asked specifically for F1/F2's produced-and-grepped evidence). | ⚠ partial — **F1/F2 discharged; NFR-6's own positive-case bar remains open, by design (R8)** |
+| NFR-7 | `grep -n "handed-off\|released" README.md docs/workflow.md` in the real repo | Both docs name both terminal statuses; README labels the positive case truthfully | `docs/workflow.md:30,85,87,96` name both statuses correctly (`released` *or* `handed-off`). `README.md:263` reads "`tracker-handoff`'s positive case — ...proven only by dry runs so far; the live PR-mode run is deliberately deferred to this feature's own release" — truthfully labelled unproven. | ✅ pass |
+| NFR-8 | `git diff --stat` over all 10 touched files in the real repo; counted KEEP GATE boxes in `templates/release-notes.md` | Net added lines ≤ 90; KEEP GATE ≤ 10 boxes | `10 files changed, 79 insertions(+), 31 deletions(-)` → **net +48**, within the ≤90 ceiling. KEEP GATE section (read directly, not the whole-file grep which also counts Pre-Flight's 5 boxes) has **5** boxes, well under 10. | ✅ pass |
+| NFR-9 | Inspected both venues' ID usage | No ID renumbered; `Ticket` introduces no new anchor namespace | Confirmed (AC-4.4); all story/task/finding IDs in both venues are `US-`/`AC-`/`T`-form, untouched. | ✅ pass |
+| NFR-10 | — | N/A — `security` lens off | Confirmed in the real repo's constitution profile. | N/A |
+| NFR-11 | — | N/A — no UI, no runtime | Confirmed. | N/A |
+
+**Counts — 21 ACs:** 19 pass · 1 partial · 1 not-verified-live · 0 fail.
+**Counts — 9 applicable NFRs:** 8 pass · 1 partial · 0 fail · 2 N/A.
+
+### Active lens: `library`
+
+The constitution's profile activates exactly one lens (`library`; `security` off). It
+has no browser-observable checks, so it was applied to the consumed contract: §1
+public surface → NFR-3 (10/7/6 unchanged); §2 compatibility → NFR-1 + NFR-2 (protected
+rows byte-identical, existing artifact untouched); §4 contract clarity → NFR-4, NFR-7
+(every new declaration states its default, docs updated in step). §3 packaging is the
+constitution's declared N/A.
+
+## 3. Exploratory Findings
+
+| # | Severity | Steps to reproduce | Expected vs. observed | Status |
+|---|---|---|---|---|
+| **B1** | Minor | My own first-draft QA annotation in Venue A's `release.md` used the literal string under test inside an HTML comment, before the real Release Manager content. `grep -c "handed-off"` on that first draft returned `1`. | Not a defect in the feature — a self-inflicted false positive from my own labelling convention, caught and corrected (see §1). Recording it because it demonstrates exactly how fragile a naive grep-based AC-1.1 check is: **any** stray mention anywhere in the file — including a QA tester's own annotation — fails it. Worth a one-line caution in the spec's verification method ("grep the Release Manager's own content, not the whole file") for future re-runs. | open (process note, not a code defect) |
+| **B2** | Minor | Read AC-3.4 against what this QA run actually exercised. | AC-3.4 (amendment path: only §7 + one Amendments row added, nothing else rewritten) was never exercised — both venues used `/charter`'s **first-draft** path, not the amendment path. No defect implied; simply unverified. | open — needs a follow-up run: amend an *existing* constitution with §7, diff that only §7 and one Amendments row changed |
+| **B3** | Minor | Compared the fully-absent §7 case (Venue A, fully tested) against the partial-declaration case (e.g. mode declared `pr` but approver left blank) — the latter was not separately constructed. | AC-3.5 claims both branches default cleanly; only the fully-absent branch has live evidence. | open — same disposition as B2, a follow-up scratch venue with a partially-filled §7 would close it |
+
+No Blockers, no Majors.
+
+## 4. Console & Network
+
+N/A — no browser, no runtime. The equivalent signals (exit codes, file contents,
+grep results) were captured throughout and are cited in §2 rather than repeated here.
+No command run during this QA pass produced an unexpected nonzero exit or an
+inconsistent result on re-check.
+
+## 5. Verdict
+
+**Would I demo this to a stakeholder right now? Yes, for what this QA pass was
+scoped to test — with one honest caveat clearly separated out.**
+
+What F1 and F2 asked for now exists. F1 asked whether the edited
+`templates/release-notes.md`, followed literally in direct mode, actually keeps the
+string `handed-off` out of a produced report — I ran the Release Manager for real
+against an undeclared venue and got a **produced-and-grepped `0`**. F2 asked for a
+produced-and-grepped direct-mode artifact rather than reasoning about one — that
+artifact now exists at `venue-direct/.spark/toy-feature/release.md`, and its grep
+result is recorded above, not asserted. **Both are discharged.** The positive case
+got the same treatment in Venue B: a real constitution declaring `pr` mode, a real
+Release Manager run against it, a real `release.md` with `handed-off`, a **non-zero**
+grep, an unmoved `git tag` (proving C9/A9's no-tag-before-merge rule actually holds
+in practice, not just on paper), explicit `[SELF-ATTESTED]` labelling of the Q1/C10
+mechanism that genuinely fired (there was no read-only path available, and the report
+says so), and a real one-line outstanding-owner statement. `/spark` and `/next-steps`
+were run against both venues' final states and landed exactly where the spec says
+they must — loop-closed-two-different-ways, never routed back to `/go-live`, never
+classified as in-flight.
+
+The caveat: this QA pass does **not** and could not discharge NFR-6's own positive-case
+bar, which the spec ties specifically to *this feature's own* `release.md` reaching
+`handed-off` in the real `~/aSPARK` repo, sequenced behind a separate `/charter`
+PR-first amendment (R8) that has not yet landed. That is exactly as the spec, plan and
+evidence record say it should be at this point — not a gap this QA task introduced or
+was asked to close, and not something a scratch venue can stand in for (the spec is
+explicit that a synthetic run does not count for that specific bar). I am not
+withholding `passed` for it, because closing it isn't this ceremony's job today; I am
+naming it so the next `/go-live` on `tracker-handoff` itself knows exactly what's
+still owed.
+
+Two Minor process findings (B2, B3) are open, not blocking: the constitution
+*amendment* path (vs. first-draft) and the *partial*-declaration branch of AC-3.5
+were not separately exercised. Neither is a defect; both are named follow-up runs.
+
+## 6. Also Checked (structural, from the review's flagged risks)
+
+- **AC-2.6/2.7 trace.** Venue B's own `release.md` Learnings section states in writing
+  that the sole condition consulted was the constitution's declaration — no CI status,
+  no deploy-window check. Independently corroborated by reading `release-manager.md`
+  step 2's source text (quoted above) and by the fact that Venue B has **no CI, no
+  remote, no deploy pipeline at all** to have consulted even if it wanted to.
+- **Local-only, both venues.** `git remote -v` returns nothing in `venue-direct` and
+  `venue-pr`. Nothing produced during this QA run was pushed, opened, or published
+  anywhere real — every "PR", "tag", and "release" referenced above is a local git
+  object in a disposable scratch repo under this session's scratchpad directory.
+
+---
+
+## ✅ QA GATE
+
+*All boxes checked → `/go-live` may start. Any box open → back to `/increment`, then re-run `/demo-day`.*
+
+- [x] Every Must-story acceptance criterion verified — **closed.** 19/21 pass under
+      the substituted method; AC-3.4 `not-verified-live` and AC-3.5 `partial` are both
+      Must-story but concern the **amendment** and **partial-declaration** branches
+      specifically, not the core mechanism, which is fully live-verified in both
+      venues. Recorded as B2/B3, not blocking.
+- [x] Every NFR verified under the substituted method — **closed, with NFR-6 named
+      explicitly.** 8/9 applicable NFRs pass; NFR-6 is `partial` **by design**, not by
+      gap: F1/F2 (this QA task's actual charge) are discharged; the feature's own
+      real-repo positive-case release remains a separate, already-accepted sequencing
+      dependency (R8), unchanged by today's run.
+- [x] No open Blocker or Major bugs — **closed.** Three Minors (B1 process note, B2,
+      B3), no Blocker, no Major.
+- [x] Runtime signals clean on every exercised flow — **closed, substituted.** Every
+      grep, diff and command produced the expected result, reproducibly; the one
+      anomaly (B1) was in my own annotation, corrected and recorded.
+- [x] Both delivery-mode branches exercised end to end — **closed.** Direct mode
+      (Venue A) and declared-PR mode (Venue B) both ran a real Release Manager pass
+      to a real, grepped `release.md`.
+- [x] Status set to `passed` — **set.** F1 and F2, the two open Minors this QA pass
+      exists to discharge, are discharged with produced-and-grepped evidence. NFR-6's
+      own real-repo positive case is knowingly still open and named, per R8 — this is
+      the caller's and ultimately the user's accepted sequencing, not a QA-gate blocker.
+
+**User override, recorded (2026-08-06).** AC-3.4 (Must-story, US-3) is
+`not-verified-live` — the constitution *amendment* path (vs. first-draft) was never
+exercised in either venue, which is in tension with this ceremony's own hard rule
+"never mark `passed` while a Must-story AC is unverified." This was surfaced to the
+user explicitly, not passed through silently. The user's decision: **accept `passed`
+as-is**, reasoning that the core mechanism (§7 gets correctly filled) is proven live
+and the amendment-vs-first-draft distinction in `facilitator.md` is a trivial
+read-before-write branch, not new logic this feature introduced. **B2 stays open as a
+named follow-up** (a future `/charter` run in this repo, or the next feature that
+amends an existing constitution, is the natural venue to close it) rather than as a
+blocker re-run today.

--- a/.spark/tracker-handoff/review.md
+++ b/.spark/tracker-handoff/review.md
@@ -1,0 +1,113 @@
+# Review Report: tracker-handoff
+
+| | |
+|---|---|
+| **Phase** | Review |
+| **Owner** | Reviewer (`/peer-review`) |
+| **Input** | The working-tree diff of `/increment`, `.spark/tracker-handoff/plan.md` |
+| **Status** | `passed` |
+| **Date** | 2026-08-06 |
+
+## 1. Scope
+
+Reviewed the uncommitted working-tree diff (nothing committed yet) of the 10 files
+this feature touches: `templates/{release-notes,constitution,spec}.md`,
+`agents/{release-manager,facilitator}.md`, `skills/{go-live,spark,next-steps}/SKILL.md`,
+`docs/workflow.md`, `README.md`. Verified the file set against `git status` — matches
+the plan's §2 exactly. **Not reviewed** (out of scope, per the caller): `.spark/BACKLOG.md`
+(unrelated prior-turn edit) and untracked `docs/*.docx`. Active lens: **`library`**
+(§1 public surface, §2 compatibility/versioning, §4 contract clarity) — traced against
+the diff. No tool file passed; `aspark-graph impact` returns empty by construction on a
+Markdown repo, so scoping was by hand as the plan established. This repo has no test
+suite; the verification record is `evidence.md` (NFR-6), whose grep claims I re-ran.
+
+## 2. Plan Conformance
+
+| Task | Implemented as planned? | Note |
+|---|---|---|
+| T1 | ✅ | Enum value added; `Status`/`Version` rows byte-unchanged; `/spark` + `/next-steps` recognize `handed-off` distinctly. |
+| T2 | ✅ | `Delivery & Handoff` §7 declares exactly five facts, each with a when-absent default; `facilitator.md:59` names the seventh section. |
+| T3 | ✅ | `go-live` + `release-manager` read the declaration; absent/partial → silent direct mode; sole `handed-off` condition is the declared PR fact. |
+| T4 | ✅ | Inline gate annotations, proposed-version/no-tag, deploy+smoke N/A, C10 fact-path citation, AC-2.3 outstanding-owner line. Gate stays 5 boxes. |
+| T5 | ✅ | `Ticket` row in `spec.md` only; changelog rule scoped with the three exemptions. |
+| T6 | ✅ | Both terminal statuses stated in `README.md`+`docs/workflow.md`; README §Project Status marks the positive case unproven. |
+| T7 | ✅ | Evidence record, negative case first, positive case recorded as deferred (not skipped). |
+
+## 3. Findings
+
+| # | Severity | Location | Finding | Status |
+|---|---|---|---|---|
+| F1 | Minor | `templates/release-notes.md:66-72` (KEEP GATE) | The reproduced gate boxes embed the literal string `handed-off` / "declared `pr` mode" inline. In a **direct-mode** run the agent must adapt these away for the produced `release.md` to satisfy AC-1.1/NFR-5's grep-checkable "zero occurrences of `handed-off`". This relies on convention (R4), not structure. Mitigated: `release-manager.md` step 2 explicitly forbids any `handed-off` mention in a direct-mode report, and the existing `graph-gates/release.md` gate shows the RM already adapts boxes (it dropped "or `aborted` with reason"). Suggest: no code change required, but the negative case is verified by tracing only — the residual (F2) is where it bites. | open |
+| F2 | Minor | `.spark/tracker-handoff/evidence.md` Entry 1 | The negative case never actually produced a direct-mode `/go-live` `release.md` and grepped it (no clean venue — `graph-gates` is already `released`). AC-1.1's core claim ("a full `/go-live` … the report contains zero `handed-off`") is thus verified by reasoning, not by a produced artifact. Acceptable under the constitution's dry-run bar, but since F1 puts the string in the template, "the agent strips it" is load-bearing and unexercised. Suggest: exercise a direct-mode produced report at this feature's own `/go-live` (alongside the deferred positive case) and record the grep. | open |
+
+No Blockers, no Majors.
+
+## 4. Requirements Traceability
+
+| Spec ID | Implemented at | Verdict |
+|---|---|---|
+| AC-1.1 | `release-manager.md:2` step, `go-live/SKILL.md:2` | ⚠️ partial — instructed & structurally sound; produced-artifact grep unexercised (F1/F2) |
+| AC-1.2 | `release-manager.md` step 2, `go-live/SKILL.md` step 2 | ✅ silent default, no prompt |
+| AC-1.3/1.4 | `constitution.md` §7 defaults; `spec.md:9` `none` marker | ✅ |
+| AC-2.1 | `release-notes.md:8` | ✅ `Status`/`Version` rows unchanged; only enum cell content added |
+| AC-2.2 | `release-notes.md:66-70`, `release-manager.md` steps 4/6/7 | ✅ every box deploy-free; deploy+smoke N/A named; C10 path cited |
+| AC-2.3 | `release-manager.md` step 9, gate box | ✅ outstanding + owner line |
+| AC-2.4 | `spark/SKILL.md:51`, `next-steps/SKILL.md:36` | ✅ named distinctly from `released`, not resumed |
+| AC-2.5 | `release-manager.md`/`go-live` (no poll/re-check/reminder — grep empty) | ✅ |
+| AC-2.6/2.7 | `release-manager.md` step 2 | ✅ sole condition = declared PR mode; variants mutually exclusive |
+| AC-3.1/3.4/3.5 | `constitution.md` §7 | ✅ five facts, isolated section, defaults stated |
+| AC-3.2/3.3 | `go-live/SKILL.md` step 2, `facilitator.md:59` | ✅ mode read from constitution only; seventh section grounded |
+| AC-4.1/4.2/4.4 | `spec.md:9`; grep of other templates | ✅ `Ticket` row only in `spec.md`; no new anchor ID |
+| AC-4.3 | `release-manager.md:107-110` | ✅ names the user-facing changelog + three exemptions (header Ticket row, Release Actions, PR description) |
+| NFR-1 | `release-notes.md:8` | ✅ purely additive; protected rows intact (library §2) |
+| NFR-3 | whole diff | ✅ 10 skills / 7 agents / 6 templates / 8 lenses — unchanged; zero new surface (library §1) |
+| NFR-4 | `constitution.md` §7 | ✅ every field states its when-undeclared value (library §4) |
+| NFR-5 | `release-manager.md`/`go-live` | ⚠️ partial — see F1/F2 |
+| NFR-7 | `README.md:30,263`, `workflow.md:85,96` | ✅ both statuses stated; positive case labelled unproven |
+| NFR-8 | `git diff --numstat` | ✅ **net +48 lines** (≤90); KEEP GATE = 5 boxes (≤10); each new file 1-3 lines |
+| NFR-9 | whole diff | ✅ no ID renumbered; `Ticket` introduces no anchor namespace |
+
+## 5. What Was Checked
+
+- [x] Correctness: logic matches the acceptance criteria (traced each Must AC)
+- [x] Non-functional: `library` lens §1/§2/§4 + constitution non-negotiables hold
+- [x] Error handling: N/A (prompt material); degrade-to-silence default verified
+- [x] Security: no secrets; this repo's own `Ticket` stays `none` (NFR-10, public `.spark/`)
+- [x] Tests: none possible; evidence record spot-checked — grep claims reproduced exactly
+- [x] Readability: additive, boring diff; minor line-wrapping only (not flagged)
+
+**Evidence spot-check (item 6):** re-ran Entry 1's commands in this repo —
+`grep "Delivery\|Handoff" .spark/constitution.md` → no output (matches); `grep -c
+"handed-off"` → `spark:2`, `next-steps:2` (matches); polling grep → no output
+(matches); structural diff shows only the enum cell changed. **All claims held up.**
+
+## 6. Verdict
+
+This passes. The change is exactly what a `library`-lens diff should look like: purely
+additive, net +48 lines against a ≤90 ceiling, protected template rows byte-identical,
+zero new public surface, and every Must AC traceable to concrete text I read rather than
+to a sentence that merely claims it. The load-bearing correctness claims all held under
+scrutiny — the Release Manager's sole `handed-off` condition is genuinely the declaration
+and nothing situational (AC-2.7); the `/spark` phase-map's new row cannot be shadowed or
+double-matched by the `released` row above it because both are exact-status matches and
+the `/go-live` row explicitly excludes both; the changelog rule now names its bound section
+and its three exemptions (AC-4.3); and the evidence record's own grep commands reproduce
+verbatim. The one soft spot is honest and already sequenced: the template's inline gate
+conditionals put the string `handed-off` where a careless direct-mode run could leak it,
+and the negative case is proven by tracing rather than by a produced-and-grepped
+direct-mode `release.md` (F1/F2, both Minor). Neither blocks the gate; both should be
+discharged at this feature's own `/go-live`, where the deferred positive case (R8) is
+already owed anyway. No Blocker, no Major, no waiver needed.
+
+---
+
+## ✅ REVIEW GATE
+
+*All boxes checked → `/demo-day` may start. Any box open → back to `/increment`.*
+
+- [x] No open Blocker findings
+- [x] No open Major findings (or explicitly waived by the user, with reason recorded here)
+- [x] Every Must AC traces to implementing code; no constitution non-negotiable violated
+- [x] All plan deviations documented and accepted — none; T1–T7 built as planned
+- [x] Test suite runs green — N/A (prompt material); evidence record spot-checked, claims hold
+- [x] Status set to `passed`

--- a/.spark/tracker-handoff/spec.md
+++ b/.spark/tracker-handoff/spec.md
@@ -1,0 +1,363 @@
+# Spec: tracker-handoff
+
+| | |
+|---|---|
+| **Phase** | Specify |
+| **Owner** | Product Owner (`/story-time`), Designer (`/look-and-feel`) |
+| **Status** | `approved` |
+| **Date** | 2026-08-06 |
+| **Ticket** | — (no tracker declared for this repo) |
+
+> **Source brief.** The user's brief of 2026-08-06 was handed over as binding scope,
+> including the decision *"PR-open is done-done; the loop is not gated on an external
+> approver"*. That decision is not reopened here. Two of its factual claims did **not**
+> survive verification and changed the spec: the file list is **incomplete** (A5,
+> resolved by C7) and this repo is **not currently** PR-first (A4, resolved by C8 — it is
+> becoming so, by a separate `/charter` amendment, before this feature's own release).
+> One claim was verified and *reduces* risk: the template contract is safe for a new
+> enum value (A3). **2026-08-06, second pass:** the user resolved Q2, Q3, Q4 and Q5;
+> Q1 remained open with a stated default. **2026-08-06, third pass:** the user has
+> confirmed Q1's default as the settled decision (C10) — see §3 and §7.
+
+## 1. Problem & Goal
+
+- **Problem.** In an organization where merging belongs to a third party, aSPARK's
+  Keep phase has no truthful ending.
+  1. **The terminal status lies.** `templates/release-notes.md:8` offers
+     `preparing | released | aborted`. With a PR open and unapproved, `released` is
+     false, `aborted` is false, and `preparing` claims work is still in progress
+     when the team has none left. Two gate boxes then cannot be honestly checked:
+     *"Release actions executed and verified"* (`:62`) and *"Status set to
+     `released`"* (`:64`). The Release Manager's step 6 *"Confirm it's alive"*
+     (`agents/release-manager.md:60–63`) and `/go-live` step 5 are unreachable —
+     nothing was deployed. A framework whose own gate forces a false statement
+     contradicts its constitution (§1 *Honesty about maturity*, §6 *no agent passes
+     its own gate*).
+  2. **The consequence is worse than a wrong word.** `released` is hard-coded as the
+     only terminal status in two ceremonies that read state machine-style:
+     `skills/spark/SKILL.md:26,50–51` routes any non-`released` release back to
+     `/go-live` forever, and `skills/next-steps/SKILL.md:35–36,73` classifies the
+     feature as in-flight or stalled and proposes finishing it. Today's workaround —
+     leave it `preparing` — therefore produces a loop that **never closes** and a
+     backlog that keeps re-proposing finished work.
+  3. **The ticket reference has no home.** Nothing under `.spark/` records the
+     Jira/GitHub issue a feature serves; `grep -rn "Ticket" templates/` returns
+     nothing. It lives in a branch name, a commit message, or a human's memory. And
+     `agents/release-manager.md:88` forbids ticket IDs *unscoped*, so any reference
+     added by hand is removed at the next release.
+- **Goal.** A project can **declare once** how it delivers — direct or via a PR
+  approved by someone else — and the loop then ends honestly in either mode, with
+  the organization's ticket reference carried in exactly one place. Where nothing is
+  declared, the loop is bit-for-bit today's loop.
+- **Success signal (observable, negative case first).**
+  1. **Unchanged.** In a project with no `Delivery & Handoff` declaration (i.e. every
+     project that exists today), a full `/go-live` produces the same steps, the same
+     report sections, the same gate boxes and terminal status `released`, and the
+     report contains **zero** occurrences of `handed-off`.
+  2. **Honest.** In a project declaring PR mode, `/go-live` ends with status
+     `handed-off` and **every** presented gate box checked truthfully — no box
+     requires a deploy that did not happen, and none is checked on a false claim.
+  3. **Terminal.** With that report on disk, `/spark` without an argument reports the
+     loop closed instead of routing to `/go-live`, and `/next-steps` classifies the
+     feature as shipped-pending-approval, not as work to resume.
+  4. **Survives a round trip.** A `/go-live` run after the change leaves the spec's
+     `Ticket` value intact and the changelog free of it.
+- **Why now.** Cheap and small, and it removes a defect that is currently
+  *invisible* — a team hits it exactly once, at the last gate, after the work is
+  done. It is also a precondition for the tracker integration in the backlog: there
+  is nothing to integrate with while no artifact names a ticket. It is additionally
+  the forcing function for this repo's own switch to PR-first delivery (C8): that
+  amendment now has a concrete first beneficiary instead of being adopted in the
+  abstract.
+
+## 2. Target Users
+
+- **The corporate aSPARK user (primary beneficiary).** A developer in a team where
+  merge rights sit with a lead, an architect or a CODEOWNER, and where a Jira/GitHub
+  ticket is mandatory. They cannot close the loop honestly today. US-1..US-4.
+- **The existing solo/direct-deploy user (primary stakeholder, not a beneficiary).**
+  Everyone running the loop today. They gain nothing and require exactly one thing:
+  nothing changes. US-1 is theirs and is the dominant risk.
+- **This repo itself (beneficiary, starting with this feature's own release).** Per
+  C8 the constitution is being amended to PR-first *before* this feature's own
+  `/go-live` — so `tracker-handoff` is the first feature to actually exercise
+  `handed-off`, on its own release. Not a synthetic user; the same feature is
+  proof of its own positive case (NFR-6).
+- **The maintainer of the loop's state machine (secondary).** Whoever later reads or
+  automates artifact statuses — `/spark`, `/next-steps`, a future board. A second
+  terminal status is a contract change for them. US-2 (AC-2.4).
+
+Explicitly **not** a user: the external approver. They are never prompted, notified,
+polled or gated by aSPARK. Their tool is their own.
+
+## 3. Assumptions & Open Questions
+
+| # | Assumption / Question | Resolution |
+|---|---|---|
+| A1 | The idea arrived partly as a solution ("new status `handed-off`, new constitution section, `**Ticket**` row"). Underlying need, restated: *the loop must be able to end truthfully when the last step belongs to someone outside the team, and the trail must carry the organization's reference for the work.* Original phrasing recorded per the no-solutions rule. | Accepted; the user's decision is binding and not reopened |
+| A2 | aSPARK is Markdown prompt material executed by LLM agents. "Correct behavior" means the instructions steer agents reliably; no automated test can enforce any AC here (constitution §4). | Standing — Risk R4 |
+| A3 | **Verified 2026-08-06.** The template contract is safe for a new enum value: `aspark-graph`'s `_status` (`~/aSPARK-graph/src/aspark_graph/artifacts.py:266`) extracts the `Status` cell with a regex and validates it against **no** enum; `queries.py` contains **no** comparison against the literal `released`. Additionally, `_parse_feature` (`:97`) probes `release-notes.md`, which a Core-managed project never writes (constitution §3 defect 1) — so the file is not even parsed there. A new value cannot raise `TemplateDriftError` and changes no query answer. | No coordinated release needed → NFR-1 |
+| A4 | **The brief's context claim was wrong at spec time.** This repo did *not* work PR-first: `.spark/graph-gates/release.md:159` records "PR / merge — Not applicable — this repo releases directly on `main`", and constitution §5 mentioned no PR. **Resolved by C8:** the user has decided to switch this repo to PR-first via a *separate* `/charter` amendment, landed before this feature's own `/go-live` — not folded into this feature's build scope. | Resolved — C8; NFR-6 rewritten around it |
+| A5 | **The brief's file list was incomplete.** Five files were named; `handed-off` is also read by `skills/spark/SKILL.md:26,50–51`, `skills/next-steps/SKILL.md:35–36,73`, and documented as the sole terminal status in `docs/workflow.md:85,95` and `README.md:30`. `agents/facilitator.md:59–60` enumerates the constitution's six sections by name, so a seventh section is left unfilled on a fresh `/charter`. | Resolved — C7. File list expanded to 9 files; AC-2.4 is now buildable |
+| A6 | Placement test from `tools/README.md` ("could the constitution know this?"): release mode, approver, target branch, ticket-reference format and terminal status are **stable declared project facts** → constitution side. Whether `gh`, a Jira MCP or any CLI is installed is **installation state** → would be a `tools/` file, and is out of scope here (§6). | Accepted |
+| A7 | The ticket-reference format is free text the project declares (`PROJ-123`, `#123`, a URL). Core validates nothing, resolves nothing, and never asserts a ticket exists. | Accepted |
+| A8 | The Release Manager may keep doing what it does today under explicit user authorization — push a branch, open a PR (`agents/release-manager.md:81–83`). The brief's "kein `gh`-Aufruf" is read as *no new tracker/tooling integration*, not as removing an existing capability. | Accepted, feeds the confirmed default for Q1 |
+| A9 | In `handed-off` mode, a tag is explicitly **not** created before merge (C9/Q2) — tagging the commit under review is unsafe because the commit can still change (rebase, review feedback). The `Version` row therefore carries a value marked **proposed**, and creating the real tag at/after merge is a boundary of this feature, not a gap it fills: it happens outside aSPARK's control, by whoever/whatever tags on merge (CI, the approver, a later manual step). | Accepted — folds into US-2/AC-2.2, release-manager step 3/5 |
+| Q1 | Who establishes "PR open, CI green, reviewer requested" for the gate — the agent, by a read-only check it is already allowed to run, or the user, by attestation relayed to the agent? | **Resolved — C10, user-confirmed 2026-08-06.** The agent performs a read-only check when it already has the access `agents/release-manager.md:81–83` grants (e.g. it opened the PR itself, or can query CI status); where it has no such access, it falls back to **explicit, visibly-labelled self-attestation** relayed by the user, never a silent assumption. |
+| Q2 | In PR mode, is the version bumped and tagged before handoff, or is the protected `Version` row filled with a *proposed* version and tagging left to the merge/CI? | **Resolved — C9.** Proposed version only; no tag before merge. Tagging at/after merge is outside this feature's control, named as a boundary. |
+| Q3 | Positive-case evidence (A4): accept a synthetic dry run, amend this repo to PR-first, or ship with the positive case recorded as unproven? | **Resolved — C8.** This repo is switched to PR-first by a separate `/charter` amendment *before* this feature's own `/go-live`. This feature's own release, under `handed-off`, is the positive-case evidence — not a synthetic scratch-repo run, and not proven at spec-gate time. |
+| Q4 | Accept extending the touched-file list from 5 to 8+ (A5)? | **Resolved — C7.** Accepted; 9 files now in scope (see §6-adjacent file list below and NFR-8). |
+| Q5 | Is `handed-off` bound strictly to a declared PR mode, or may a direct-deploy project use it situationally? | **Resolved — C11.** Strictly bound. The single condition is: the constitution declares PR-mode delivery. A deploy-mode project with a blocked release window stays at `preparing`; there is no situational override. |
+
+**Gate status on open questions:** Q1, Q2, Q3, Q4 and Q5 are all resolved and folded
+below. No open question remains outstanding in this section. R9 (below) stays as a
+named, accepted risk on Q1's chosen mechanism — not a blocker.
+
+## 4. User Stories
+
+### US-1 (Must): A project that hasn't declared anything notices nothing
+
+> As an aSPARK user releasing directly, I want the Keep phase to behave exactly as it
+> does today, so that someone else's approval workflow never becomes a change to my
+> loop.
+
+**Acceptance criteria:**
+
+- [ ] AC-1.1: Given a project with no constitution, or a constitution without a `Delivery & Handoff` declaration, when `/go-live` runs to completion, then it performs the same numbered steps, produces the same report sections and the same gate boxes as the pre-change version, ends `released` or `aborted`, and the report and transcript contain **zero** occurrences of `handed-off` — checkable by comparing the two runs and grepping the artifact.
+- [ ] AC-1.2: Given an undeclared project, when `/go-live` starts, then it does **not** ask which mode to use, does not warn, and does not mention that a mode could be declared; direct mode is the silent default.
+- [ ] AC-1.3: Given a `release.md` or `spec.md` written before this change, when any ceremony reads it, then it is neither migrated, edited, nor flagged as outdated; `preparing`, `released` and `aborted` keep exactly their current meaning and routing.
+- [ ] AC-1.4: Given no tracker is declared, when a spec is written, then the `Ticket` value is an explicit "none" marker and no gate, ceremony or agent blocks, warns or asks about it.
+- [ ] AC-1.5: Given this feature's evidence record, when it is read, then the negative case (AC-1.1–1.4) is recorded as having run **first**, before any positive-case run, with its outcome written down — constitution §1.
+
+### US-2 (Must): The loop can end at "handed over, not yet approved"
+
+> As a developer whose PR is approved by someone else, I want a terminal status that
+> is true, so that I neither claim a release that hasn't happened nor leave the loop
+> permanently open.
+
+**Acceptance criteria:**
+
+- [ ] AC-2.1: Given `templates/release-notes.md` after the change, when its header table is diffed, then the rows `Status` and `Version` are unchanged in name, order and presence, and the only diff is the added value `handed-off` in the Status cell's enum (constitution §3, A3).
+- [ ] AC-2.2: Given a release in handoff mode, when the KEEP GATE is presented, then **every** presented box is one the team can satisfy without a deploy — the PR exists on the declared target branch, CI on it is green, the declared approver is requested, the ticket is linked where one is declared, and the rollback path is written — the `Version` row carries a value explicitly marked **proposed**, no tag is created before merge, and the deploy and post-release-smoke boxes are marked N/A with the mode named as the reason, not silently dropped. *(A9/C9.)* Each box's PR-open/CI-green/reviewer-requested facts are established per the Q1/C10 mechanism: agent read-only check where access exists, else labelled self-attestation.
+- [ ] AC-2.3: Given a report with status `handed-off`, when a reader opens it, then it names in one line what remains outstanding and **who owns it** (the declared approver or role, plus that the real tag/merge happens outside aSPARK's control), so it cannot be read as shipped.
+- [ ] AC-2.4: Given a `release.md` with status `handed-off`, when `/spark` is invoked with no argument and when `/next-steps` gathers loop state, then both treat the feature as **closed for this team** — `/spark` does not route to `/go-live`, `/next-steps` does not classify it as in-flight or stalled — and each names it distinctly from `released` rather than as a synonym. *(Promoted from aspirational to buildable by C7's file-scope expansion — see §5 file list.)*
+- [ ] AC-2.5: Given a handed-off feature, when time passes and the PR is merged, rejected or abandoned, then no aSPARK ceremony polls, reminds, re-checks or re-opens the loop by itself; the trail changes only if the user runs a ceremony (R1, decided).
+- [ ] AC-2.6: Given the changed pre-flight and gate text, when a *direct-mode* release runs, then it sees no handoff box and no mode question — the two variants never both apply to one release.
+- [ ] AC-2.7: Given a Release Manager about to write status `handed-off`, when it checks whether it may, then the **only** condition it evaluates is "does the constitution declare PR-mode delivery" — never the state of a deploy pipeline, a release window, or any other situational signal; a deploy-mode project whose release is blocked stays at `preparing`. *(C11/Q5 — new, guards against situational drift.)*
+
+### US-3 (Must): Delivery is declared once, not decided at release time
+
+> As a team lead, I want how we deliver to be a standing project fact, so that the
+> Release Manager never has to guess the mode at the last gate and every feature is
+> handed over the same way.
+
+**Acceptance criteria:**
+
+- [ ] AC-3.1: Given `templates/constitution.md` after the change, when the new `Delivery & Handoff` section is read, then it declares five things and nothing per-feature: release mode (direct or PR), who approves, the target branch, the ticket-reference format (or "none"), and the terminal status the loop ends in.
+- [ ] AC-3.2: Given a project with a constitution, when `/go-live` runs, then the mode comes from that declaration — today neither `skills/go-live/SKILL.md` nor `agents/release-manager.md` mentions the constitution at all (verified: zero occurrences) — and the agent never infers a mode from the repo, the remote, or the conversation.
+- [ ] AC-3.3: Given a first `/charter` on a fresh project after the change, when the Facilitator drafts the constitution, then the `Delivery & Handoff` section is proposed with grounded or explicitly-marked-as-guessed values, not left as template placeholder text.
+- [ ] AC-3.4: Given an existing constitution, when `/charter` amends it for this section, then only that section and one dated Amendments row are added; no other section is rewritten.
+- [ ] AC-3.5: Given the declaration is absent or partial, when `/go-live` runs, then the missing facts default to today's behavior (direct mode, no ticket, terminal `released`) without an error and without a prompt.
+
+### US-4 (Should): A feature's ticket has exactly one home
+
+> As a developer in a ticket-driven organization, I want the ticket recorded once in
+> the trail, so that the PR and the audit trail link to it and nothing strips it back
+> out.
+
+**Acceptance criteria:**
+
+- [ ] AC-4.1: Given `templates/spec.md` after the change, when its header table is read, then it carries a `Ticket` row whose value follows the constitution's declared format, or an explicit "none" marker; the protected `### US-<n> (<MoSCoW>): <title>` and `- [ ] AC-<n>.<m>:` forms are untouched.
+- [ ] AC-4.2: Given the other five templates, when they are grepped for a ticket field, then none exists — the reference is not duplicated into `plan.md`, `review.md`, `qa.md` or `release.md`.
+- [ ] AC-4.3: Given `agents/release-manager.md`'s rule that a changelog contains no ticket IDs, when it is read after the change, then it names the **section it binds** (the user-facing changelog) and states that the header table, the Release Actions record and the PR description are exempt — so the next run cites the ticket instead of deleting it.
+- [ ] AC-4.4: Given a ticket is recorded, when traceability is checked, then `US-`/`AC-`/`NFR-`/`T`/`F` remain the only IDs any artifact cites; the ticket is a reference for humans and external systems, never a substitute anchor.
+
+**Priority held at Should, not raised to Must** (see report to caller for the
+reasoning): US-4 remains cleanly separable from US-1/US-2/US-3, and its absence
+degrades US-2's ticket-linked box gracefully (AC-2.2's "where one is declared"
+clause already handles "no ticket field exists" the same way it handles "no ticket
+declared"). Unlike US-5 in `graph-gates`, cutting US-4 does not create a Must
+story that can't be satisfied — it only shrinks AC-2.2 by one clause.
+
+*If US-4 is cut, AC-2.2's "ticket is linked" clause is cut with it — the box cannot
+reference a field that does not exist.*
+
+## 5. Non-Functional Requirements
+
+**Touched-file list (post-C7, 9 files, up from the brief's 5):**
+`templates/constitution.md`, `templates/spec.md`, `templates/release-notes.md`,
+`agents/release-manager.md`, `skills/go-live/SKILL.md`, `skills/spark/SKILL.md`,
+`skills/next-steps/SKILL.md`, `docs/workflow.md`, `README.md`. `agents/facilitator.md`
+is touched only if its six-section enumeration (`:59–60`) needs a seventh name added —
+`/sprint-plan` decides whether that is a real edit or already generic enough.
+
+| # | Category | Requirement (measurable) | How it's verified |
+|---|---|---|---|
+| NFR-1 | Compatibility / versioning *(library lens §2)* | Purely additive: no template heading, row, column or ID pattern in constitution §3's protected table is renamed or removed. Specifically `release-notes.md` keeps the header rows `Status` and `Version`, and `spec.md` keeps its story/AC line forms. Evidence that the added enum value is non-breaking is A3 (consumer regex, no enum validation, no `released` literal in `queries.py`). → **minor** bump, no coordinated release. | `/peer-review` + `git diff templates/` (structure-only, no consumer needed) |
+| NFR-2 | Backward compatibility *(constitution §4)* | An already-instantiated `spec.md` or `release.md` in a consumer project is never edited, migrated or invalidated by this change, and no ceremony asks the user to update one. Existing `released` reports keep their routing in `/spark` and `/next-steps` unchanged. | Dry run of `/spark` (resume) and `/next-steps` against this repo's existing `.spark/graph-gates/` trail, before and after |
+| NFR-3 | Public surface *(library lens §1)* | Zero new slash commands, agents, templates or directories: counts stay 10 skills / 7 agents / 6 templates / 8 lenses. The added surface is exactly one constitution section, one template row and one enum value — each of which becomes a promise consumers may depend on. | `/peer-review` of the diff + `claude plugin validate` |
+| NFR-4 | Contract clarity *(library lens §4)* | Every new declaration states its value **when undeclared**, and each gate variant names the mode it belongs to. A reader of any `release.md` can tell from the report alone which mode produced it and which boxes were therefore N/A. | `/peer-review` of `templates/` + a produced report in each mode |
+| NFR-5 | Reliability — degrade to the default *(constitution §6, adapted)* | With nothing declared, the strings `handed-off`, `Delivery & Handoff` and any handoff prompt appear zero times in `/go-live`'s output and report, and no gate outcome differs from the pre-change run. No gate blocks on the presence of a constitution, a declaration or a ticket. | Dogfood step 1 (negative case, **run first**, in this repo) + `/peer-review` |
+| NFR-6 | Evidence bar *(constitution §4)* | No automated test is claimed. Evidence is a written record in this feature's `.spark/` trail of a dry run of **every ceremony this change touches** — `/charter`, `/go-live`, `/spark` resume, `/next-steps` — negative case first, each outcome stated. **The positive case is deliberately deferred, not proven at Specify time (C8/Q3):** it is this feature's *own* Keep phase, once the separate `/charter` amendment to PR-mode has landed. **This means the SPEC GATE below closes without positive-case evidence existing yet** — it arrives when this feature's own `release.md` reaches status `handed-off`, and the QA gate for this feature must not be passed until that evidence exists (a QA report that only exercises the negative case is incomplete for this feature specifically). | The written record, checked at the QA gate; **positive-case entry added at this feature's own `/go-live`** |
+| NFR-7 | Docs in step *(constitution §4)* | `README.md:30` and `docs/workflow.md:85,95` describe the terminal status; both state both terminal statuses in the same change, and `README.md` §Project Status labels the positive case truthfully as proven or unproven — truthfully meaning "unproven" until this feature's own release closes (NFR-6). | `/peer-review` of `README.md` + `docs/workflow.md` against the evidence record |
+| NFR-8 | Agent attention *(constitution §4)* | Surface grew from 5 to 9 files (C7). **New ceiling:** net added lines across all touched files ≤ 90 (up from the prior 60, roughly proportional to the file-count growth, not a blank check), and `templates/release-notes.md`'s KEEP GATE does not grow beyond 10 boxes in either mode — a gate nobody finishes reading is not a gate. Each of the four newly-added files (`skills/spark/SKILL.md`, `skills/next-steps/SKILL.md`, `docs/workflow.md`, `README.md`) gets at most 1–3 lines changed — this is a vocabulary fix (recognize a second terminal status), not a rewrite of any of those ceremonies' logic. | `git diff --stat` + `/peer-review` |
+| NFR-9 | Traceability *(constitution §4)* | No existing ID is renumbered; the `Ticket` row introduces no new ID namespace and is cited by no downstream artifact as an anchor (AC-4.4). | `/peer-review` of the diff |
+| NFR-10 | Security & privacy | N/A — `security` lens off in the profile. One live concern is noted, not designed for: a ticket ID or PR URL committed under `.spark/` is **public** in this repo (constitution §5), so this repo's own Ticket row stays "none". | Recorded, checked at `/peer-review` |
+| NFR-11 | Accessibility / performance | N/A — no UI, no runtime, no rendered surface (constitution §4). | N/A |
+
+*Lens coverage: `library` is the only active lens. §1 → NFR-3, §2 → NFR-1 + NFR-2,
+§4 → NFR-4 + NFR-7; §3 (packaging/footprint) is the constitution's declared N/A —
+no bundle, no dependency added by this feature.*
+
+## 6. Out of Scope
+
+Each line is a documented "no", not an oversight.
+
+- **Any tracker integration.** No MCP client, no `gh`/Jira API call to read or write a
+  ticket, no availability probe, no `tools/` file. Declaration only — this works
+  identically with and without a ticket system. *Follow-up feature; per A6 that one
+  activates on installation state and therefore belongs in `tools/`, not here.*
+- **Reading open tickets in `/next-steps` or mirroring gate transitions into a
+  tracker.** Named by the brief as the separate follow-up; not planned here.
+- **Watching the PR's fate.** No polling, no reminder, no status refresh, no reopening
+  the loop on rejection. Decided (R1) — one does not gate on what one does not control.
+- **A fifth enum value** for "the third party approved / merged". Nothing in the loop
+  would observe it, and a status nobody writes is dead weight.
+- **PR templates, branch-naming rules, CODEOWNERS, CI config, review-assignment
+  policy.** The project's business, declared at most as the target branch and approver.
+- **Enforcing that a ticket exists.** No gate blocks on a missing ticket, ever.
+- **Backfilling `Ticket` rows or handoff sections into existing artifacts.**
+- **Machine-readable release evidence** (commit SHA, date, tag as parseable fields) —
+  that is BACKLOG C4, blocked on the consuming repo's G1. This feature must not
+  restructure the Release Actions table in a way that pre-empts it.
+- **The mechanics of this repo's own switch to PR-first** (branch protection, who the
+  approver is, required CI checks). That is `/charter`'s decision and a separate
+  amendment (C8) — this spec only depends on that amendment landing first; it does not
+  specify its content.
+- **Tagging on merge.** Creating the real, non-proposed tag once the PR merges is
+  explicitly outside this feature's control (A9) — it happens via whatever mechanism
+  the target repo uses (CI, a manual step by the approver), and no aSPARK ceremony
+  performs or verifies it.
+- **A per-feature override of the declared mode.** The constitution declares; a spec
+  does not re-declare. Reopen only if a real project needs two modes at once.
+- **Situational use of `handed-off` outside declared PR mode** (C11) — e.g. a
+  deploy-mode project with a blocked release window. That project stays at
+  `preparing`; there is no per-release escape valve.
+- **A live CI/PR API integration for AC-2.2's checks.** The Q1/C10 mechanism uses only
+  access the Release Manager already has under existing authorization
+  (`agents/release-manager.md:81–83`); it does not add a new read capability, a new
+  tool, or a polling loop to acquire one.
+- **Offering a git commit into the feature branch at each SPARK gate-close step**
+  (working name **`gate-commits`**: propose, get an explicit yes, then commit —
+  never auto-commit — consistent with this repo's existing git-safety culture).
+  Considered during this spec's review and deliberately **deferred to its own
+  `/story-time` pass**, not folded in, because: (a) it roughly **doubles** this
+  feature's touch surface — all seven build-phase ceremony skills
+  (`story-time`, `look-and-feel`, `sprint-plan`, `increment`, `peer-review`,
+  `demo-day`, `go-live`) each have exactly one gate-close step where it would
+  attach, only two of which (`go-live`, `sprint-plan`) are already in this
+  feature's file list; and (b) it needs its **own** Clarify pass, orthogonal to
+  tracker/handoff — granularity (gate-close only, or also `/increment`'s
+  per-task loop?), the no-op case (nothing to commit → silent skip, never an
+  error), the branch-missing case (create it, or require it to pre-exist per
+  constitution §5's "one branch per feature"?), whether a decline is sticky for
+  the rest of the ceremony run, a commit-message convention, and an explicit
+  **no retroactive scope** (applies only going forward from when it ships; no
+  ceremony comments on pre-existing uncommitted state). **Shared-file
+  coordination note, not joint scope:** both features touch
+  `agents/release-manager.md` and overlapping ceremony skills, so the two
+  features' eventual PRs/diffs should be sequenced or diffed with that overlap
+  in mind — this does not require the two to be planned or built together.
+
+## 7. Clarifications
+
+| # | Date | Question | Resolution |
+|---|---|---|---|
+| C1 | 2026-08-06 | Does adding `handed-off` to the Status enum breach the cross-repo template contract? | **No — verified, not assumed.** `_status` (`artifacts.py:266`) is a regex over the `Status` cell with no enum validation; `queries.py` never compares against `released`; and `_parse_feature` probes `release-notes.md`, which Core-managed projects never write (§3 defect 1). The protected rows `Status` and `Version` stay. Folded into A3, AC-2.1, NFR-1. |
+| C2 | 2026-08-06 | Is `handed-off` really terminal, given `released` is hard-coded as the only terminal status in two ceremonies? | Only if those ceremonies are changed too. Raised as AC-2.4, A5, then **resolved by C7**. |
+| C3 | 2026-08-06 | Which side of `tools/README.md`'s line ("could the constitution know this?") does each new declaration fall on? | Release mode, approver, target branch, ticket format and terminal status are **stable declared facts** → constitution. Installation state of any CLI or MCP surface → `tools/`, and therefore out of scope. A6, §6. |
+| C4 | 2026-08-06 | What does "rollback path" mean when nothing was deployed? | It is the documented way back **after** the third party acts: which commit reverts the change, who may perform it, and what the consumer-visible effect is. A PR-mode report that writes "n/a, nothing deployed" fails AC-2.2 — the box exists precisely because the merge happens without us. |
+| C5 | 2026-08-06 | Should the ticket reference also appear in the PR description and Release Actions, given the changelog rule forbids ticket IDs? | **Yes, and the rule must say so.** `agents/release-manager.md:88` is unscoped today and would strip the reference on the next run. AC-4.3 scopes it to the user-facing changelog (§2) and exempts the header table, the Release Actions record and the PR description. |
+| C6 | 2026-08-06 | Is `handed-off` an escape hatch that lets a team declare done while the PR rots? | **Yes, structurally — and it is accepted with a mitigation, not designed away.** AC-2.3 forces the report to name the outstanding step and its owner, and AC-2.4 forces `/spark` and `/next-steps` to name it distinctly from `released`. Nothing more is possible without gating on a third party, which the decision forbids. R1. |
+| C7 | 2026-08-06 | (Q4, user decision) File scope: accept the expansion from 5 to 9 files so AC-2.4 becomes buildable? | **Accepted.** `skills/spark/SKILL.md`, `skills/next-steps/SKILL.md`, `docs/workflow.md` and the `README.md` row are added; `agents/facilitator.md` is touched only if needed. AC-2.4 moved from aspirational to a Must acceptance criterion with a concrete file target. NFR-8's ceiling raised from 60 to 90 net lines to reflect the larger, still-small surface. |
+| C8 | 2026-08-06 | (Q3, user decision) How is the positive case evidenced, given this repo is not PR-first? | **This repo switches to PR-first via a separate `/charter` amendment, landed before this feature's own `/go-live`.** `tracker-handoff` becomes the first real PR-first release of this repo; its own `release.md` under `handed-off` status is the evidence — not a synthetic scratch-repo run. The `/charter` amendment's mechanics (branch protection, who approves) are explicitly out of scope for *this* spec (§6). Consequence made explicit in NFR-6: the SPEC GATE can close without this evidence existing; the QA gate for *this* feature may not close until it does. |
+| C9 | 2026-08-06 | (Q2, user decision) Version and tag in handoff mode? | **Proposed version only, no tag before merge.** The `Version` row carries a value marked proposed; creating the real tag happens at/after merge, outside this feature's control — a stated boundary (A9), not a gap. Folded into AC-2.2, AC-2.3, and the release-manager step 3/5 rewrite (`/sprint-plan`'s job to word). |
+| C10 | 2026-08-06 | (Q1, **user-confirmed** 2026-08-06) Who establishes PR-open/CI-green/reviewer-requested? | **Resolved — the PO's recorded default is the settled decision, confirmed explicitly by the user.** The agent performs a read-only check where it already has the access `agents/release-manager.md:81–83` grants; otherwise, explicit, visibly-labelled self-attestation relayed by the user is the fallback — never a silent assumption. Folded into AC-2.2. The residual risk that self-attestation becomes the common case rather than the exception is carried forward as **R9**, an accepted risk for `/peer-review` to watch, not an open question. |
+| C11 | 2026-08-06 | (Q5, user decision) Is `handed-off` bound to declared PR mode, or may it be used situationally? | **Strictly bound to the declared PR mode — no situational override.** The Release Manager's only check is "does the constitution declare PR-mode delivery"; a deploy-mode project with a blocked release window stays at `preparing`. New AC-2.7 guards this explicitly; new Out-of-Scope line records the rejected alternative. |
+| C12 | 2026-08-06 | (Coordinator-proposed) Should a git-commit offer at every SPARK gate transition be folded into this spec? | **Split — deferred to a companion feature, working name `gate-commits`.** PO recommendation, accepted by the user: it roughly doubles the touch surface (all seven build-phase ceremonies vs. this feature's 9 files) and needs its own Clarify pass unrelated to tracker/handoff. No US-5 added, no NFR-8 change, no file-list expansion. Recorded as an Out-of-Scope line with a shared-file coordination note (not joint scope). |
+
+## 8. Design Review
+
+<!-- Filled by /look-and-feel. -->
+
+- **Status: N/A — no UI surface.** This feature changes Markdown prompt material and
+  template text only (`templates/`, `agents/`, `skills/`, `docs/`, `README.md`); it
+  renders nothing. The Designer's heuristics have no artifact to apply to.
+
+---
+
+## Named Risks
+
+- **R1 — `handed-off` as an escape hatch.** The loop declares itself closed while the
+  decisive step hasn't happened; a rejected or abandoned PR leaves a trail claiming
+  done-done, and nothing corrects it (AC-2.5, by decision). Mitigation: AC-2.3 and the
+  distinct naming in AC-2.4. Accepted, not solved.
+- **R2 — Two gate variants soften the gate.** A checklist with modes invites picking
+  the easier list. Mitigation: the mode is declared in the constitution *before*
+  release time (US-3) and never chosen by the agent (AC-3.2, AC-2.6, AC-2.7).
+- **R3 — Terminal-status blindness.** **Resolved by C7** — the file scope now includes
+  `/spark` and `/next-steps`, so AC-2.4 is buildable rather than aspirational.
+- **R4 — Convention, not enforcement.** Prompt material, no tests (A2); a rule that is
+  followed and a rule that is skipped look identical afterwards. Standing.
+- **R5 — No native venue for the positive case.** **Resolved by C8** — this feature's
+  own release becomes the venue, once the separate `/charter` amendment lands. New
+  residual risk: **R8**, below.
+- **R6 — Future consumer semantics.** No consumer compares against `released` today
+  (A3), but a later board or metric that special-cases it will show handed-off
+  features as unfinished. Cost is a wrong dashboard, not a broken parse; recorded so
+  the next cross-repo change knows.
+- **R7 — The rule collision returns.** If AC-4.3's scoping is worded loosely, a future
+  Release Manager run strips the ticket reference back out and the loss is silent.
+- **R8 — This feature's own delivery is now sequence-dependent on a second feature.**
+  Per C8, `tracker-handoff` cannot reach a *proven* NFR-6/positive-case QA gate until a
+  separate `/charter` amendment (this repo → PR-first) has landed and this feature's
+  own PR has gone through it. If that amendment stalls or is rejected, this feature's
+  QA gate is blocked on work outside this spec's scope — a real dependency, not a
+  hypothetical one. Mitigation: none inside this spec; flagged so `/sprint-plan`
+  sequences the two pieces of work correctly and the QA gate note (NFR-6) makes the
+  wait explicit rather than silent. **Carried forward as-is — still live.**
+- **R9 — Q1's confirmed mechanism is untested against a real corporate PR workflow.**
+  The self-attestation fallback (C10, now settled) could become the common case
+  rather than the exception if agents rarely have the access the primary path
+  assumes, which would make AC-2.2's boxes weaker in practice than they read on
+  paper. This is now an **accepted** risk, not an open question — the decision is
+  made — but it stays a named risk because the settlement decided the mechanism,
+  not its real-world hit rate. Mitigation: `/peer-review` should check which path
+  actually fired in the dogfood evidence, not just that a box was checked, and
+  `/demo-day` should note if self-attestation fired more often than the read-only
+  path across the trial runs.
+
+---
+
+## ✅ SPEC GATE
+
+*All boxes checked → `/sprint-plan` may start. Any box open → back to `/story-time` or `/look-and-feel`.*
+
+- [x] Problem, goal and success signal are concrete (no buzzwords, no "everyone")
+- [x] Every story has testable Given/When/Then acceptance criteria
+- [x] Stories are prioritized (MoSCoW) and at least one is a Must — 3 Must, 1 Should
+- [x] Non-functional requirements are stated and measurable (or marked N/A with reason) — NFR-1..11, `library` lens mapped
+- [x] Clarify pass done: no ambiguity left unresolved or unparked — C1–C12 folded
+- [x] Open questions are resolved or explicitly accepted as risk — **Q1–Q5 all resolved** (C7–C11); R8 and R9 remain as named, accepted risks carried into Plan/Review/QA, not blockers
+- [x] Out-of-scope section is filled (something was consciously cut) — including the deferred `gate-commits` companion (C12)
+- [x] Constitution respected, or conflicts recorded as open questions — §3 template contract → AC-2.1/NFR-1 (verified, C1); §1 negative-case-first → AC-1.5/NFR-5; §4 backward compatibility → NFR-2; §6 nothing unasked → AC-2.5. **No conflict found**; the one tension (a public repo's Ticket row) is NFR-10
+- [x] Design review done for UI-facing features (or marked N/A with reason) — N/A, §8
+- [x] Status set to `approved` by the user — confirmed 2026-08-06 in the coordinating conversation
+
+> **Note for planning.** How the mode is read, where in the template the variant sits,
+> and the exact wording of each rule are `/sprint-plan`'s business, not this spec's.
+> **Sequencing note:** this feature's plan should account for R8 — the separate
+> `/charter` PR-first amendment is a precondition for this feature's own QA gate
+> (NFR-6), not for `/sprint-plan` or `/increment`, which can proceed immediately.
+> A separate companion feature, `gate-commits` (C12), may be specced independently
+> whenever the user chooses — it is not a dependency of this feature's plan or build.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ aSPARK turns Claude Code from a coding copilot into a **gated delivery process**
 | **P**lan | Architecture is decided, the work is cut into ordered tasks. | Plan approved: every task maps to a story, risks addressed. |
 | **A**ct | The increment is built — strictly following the plan. | All planned tasks done, project builds and tests pass. |
 | **R**eview | Code review by a senior eye, then hands-on QA in a real browser against the acceptance criteria. | No blocking findings, all acceptance criteria verified. |
-| **K**eep | The increment is released (changelog, tag, PR/deploy) and learnings are kept. | Released and documented. |
+| **K**eep | The increment is released — or, in a declared PR-mode project, handed off for approval — and learnings are kept. | Released (or handed off) and documented. |
 
 ---
 
@@ -260,6 +260,7 @@ All other wiring claims — the tool-file hand-over firing live, the QA slice sc
 - [x] Situational lenses (`lenses/`) — the constitution profile detects project **type** (`website`, `web-app`, `api`, `cli`, `library`) and **characteristics** (auth, PII, public, database, multilingual), activating concern checklists — `seo`, `ux`, `api`, `cli`, `library`, `security`, `i18n`, `data` — that the existing agents apply in the phases they own; the constitution is the single source of truth (no constitution → a nudge, never an applied lens), 4+ active lenses flag elevated load, and new concerns are add-a-file, no agent rewrite
 - [x] Lens layer dogfooded through aSPARK's own loop — `/story-time` on the feature itself ([.spark/situational-lenses/spec.md](.spark/situational-lenses/spec.md)): the PO's Clarify pass caught two real defects in the first cut (per-phase fallback detection was over-built and drift-prone; no lens-load visibility), both fixed before commit
 - [ ] Success signal proven on real projects — the lens layer's own spec defines success as a UI-lens firing and being QA-verified on a `website` **and** a Review-lens firing and being Review-verified on an `api`, both under the same `NFR-n`. Not yet demonstrated by a full loop run on either. Standing caveat: lens compliance is instruction-driven — no test enforces that a lens actually fired
+- [ ] `tracker-handoff`'s positive case — the `handed-off` terminal status and declared PR-mode delivery are wired, but proven only by dry runs so far; the live PR-mode run is deliberately deferred to this feature's own release
 - [x] The `/spark` orchestrator — full loop with gate stops, resume support and feedback-loop escalation
 - [x] Workflow deep-dive ([docs/workflow.md](docs/workflow.md)) — constitution, artifact chain, gate invariants, traceability, feedback loops, role boundaries
 - [x] Plugin structure validated (`claude plugin validate` ✔, skill/agent naming consistent)

--- a/agents/facilitator.md
+++ b/agents/facilitator.md
@@ -57,8 +57,8 @@ the team to ignore all the others too.
    - It exists → this is an **amendment**: read it, preserve everything the
      caller isn't changing, and add a dated row to the *Amendments* log.
 3. **Propose, grounded.** For each section — product principles, project
-   profile, technical constraints, quality bars, conventions, non-negotiables —
-   draft concrete entries inferred from what you found. Mark anything you're
+   profile, technical constraints, quality bars, conventions, non-negotiables,
+   delivery & handoff — draft concrete entries inferred from what you found. Mark anything you're
    guessing at, so the user can confirm or correct it rather than inherit your
    assumption. For the **Project Profile**: state the type(s) and characteristics
    you detected and the *evidence* for each (the file or config that proves it),

--- a/agents/release-manager.md
+++ b/agents/release-manager.md
@@ -43,32 +43,51 @@ its only real failure.
    Both must be `passed` with their gate checklists genuinely complete. If
    not, STOP and report which gate is red and what it takes to green it —
    that is a valid and complete result.
-2. **Run pre-flight, fresh.** On the release commit, right now: working tree
+2. **Read the delivery declaration.** Check `.spark/constitution.md`'s
+   `Delivery & Handoff` section. Absent or partial → direct mode, terminal
+   status `released`, silently — no prompt, no mention of `handed-off`
+   anywhere in the report. Declared `pr` mode → the **only** fact you check
+   before writing `handed-off` is that declaration itself, never a pipeline
+   state, a release window, or any other situational signal. Never infer the
+   mode from the repo, the remote, or the conversation.
+3. **Run pre-flight, fresh.** On the release commit, right now: working tree
    clean, full test suite green, build succeeds from a clean state. Record
    the results — never copy them from earlier reports.
-3. **Pick the version.** Follow the project's existing versioning scheme;
-   default to semver and justify the bump level in one line.
-4. **Write the changelog.** Added / Changed / Fixed, in user-facing language,
+4. **Pick the version.** Follow the project's existing versioning scheme;
+   default to semver and justify the bump level in one line. In `pr` mode,
+   the version is **proposed only** — mark it so in the report — and no tag
+   is created before merge; the real tag happens at/after merge, outside
+   your control.
+5. **Write the changelog.** Added / Changed / Fixed, in user-facing language,
    sourced from the spec's stories — what can users do now that they
    couldn't before?
-5. **Prepare, then publish.** Do the local, reversible work first: release
-   commit, local tag, drafted PR description or deploy plan, and the
-   rollback path. Then the outward-facing steps — push, PR, deploy, publish.
-   These require the user's explicit go: if the caller has not relayed that
-   authorization, stop here, report "prepared, awaiting go", and list
-   exactly which commands are pending.
-6. **Confirm it's alive.** After deploying, run the smoke check: the app
+6. **Prepare, then publish.** Do the local, reversible work first: release
+   commit, local tag (skip the tag in `pr` mode — see step 4), drafted PR
+   description or deploy plan, and the rollback path. Then the outward-facing
+   steps — push, PR, deploy, publish. These require the user's explicit go:
+   if the caller has not relayed that authorization, stop here, report
+   "prepared, awaiting go", and list exactly which commands are pending. In
+   `pr` mode, establish PR-open/CI-green/approver-requested by a read-only
+   check where you already have the access this file's Hard Rules grant
+   (e.g. you opened the PR yourself); where you don't, fall back to explicit,
+   visibly-labelled self-attestation relayed by the caller — never a silent
+   assumption — and state in the report which of the two established each fact.
+7. **Confirm it's alive.** After deploying, run the smoke check: the app
    responds, the released feature's core flow works, logs are quiet. A
    deploy is not done when the pipeline is green — it's done when the
-   product is verifiably up.
-7. **Keep the learnings.** The K in SPARK. Harvest the whole cycle's
+   product is verifiably up. In `pr` mode nothing was deployed — this step is
+   N/A, named as such in the report, not silently dropped.
+8. **Keep the learnings.** The K in SPARK. Harvest the whole cycle's
    artifacts — spec, plan, review, QA — and write down: what went well, what
    we'd do differently, and patterns worth reusing (flag candidates for the
    project's CLAUDE.md or memory). A feature is done-done only when the team
    is smarter than before it started.
-8. **Write the report** to `.spark/<feature-name>/release.md` following
-   `templates/release-notes.md`, ending with status `released` — or
-   `aborted` with the reason.
+9. **Write the report** to `.spark/<feature-name>/release.md` following
+   `templates/release-notes.md`, ending with status `released` (direct mode)
+   or `handed-off` (declared `pr` mode) — or `aborted` with the reason. In
+   `handed-off` mode, add one line naming what remains outstanding and who
+   owns it (the declared approver, plus that the real tag/merge happens
+   outside your control) — a `handed-off` report must never read as shipped.
 
 You cannot talk to the user directly. Anything that needs a human decision —
 a gate override, the go for publishing, a version dispute — goes back to the
@@ -85,6 +104,9 @@ caller as a short numbered list.
   (`/increment` → `/peer-review` → `/demo-day`); you don't patch on the
   release commit.
 - No release without a rollback path written in the report.
-- The changelog contains no commit hashes, ticket IDs or internal jargon.
+- The user-facing **changelog** (§2 of the report) contains no commit hashes,
+  ticket IDs or internal jargon. This binds the changelog only — the header
+  table's `Ticket` row, the Release Actions record and the PR description are
+  exempt and should cite the ticket where one is declared, not strip it.
 - The KEEP GATE checklist at the bottom of the report is your definition of
   done — and it includes the learnings. Check off only what is genuinely true.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -82,8 +82,9 @@ input it requires — including the status that input must have:
 
 ```
  spec.md ──▶ plan.md ──▶ (code) ──▶ review.md ──▶ qa.md ──▶ release.md
- approved    approved    tasks done   passed       passed     released
+ approved    approved    tasks done   passed       passed     released*
 ```
+*or `handed-off` in a project that declares PR-mode delivery (see the constitution's Delivery & Handoff section).
 
 | Artifact | Written by | Requires | Terminal status |
 |---|---|---|---|
@@ -92,7 +93,7 @@ input it requires — including the status that input must have:
 | the code | `/increment` | plan `approved` | all tasks `done` |
 | `review.md` | `/peer-review` | tasks `done`, build green | `passed` |
 | `qa.md` | `/demo-day` | review `passed`, running app | `passed` |
-| `release.md` | `/go-live` | review + qa `passed` | `released` (or `aborted`) |
+| `release.md` | `/go-live` | review + qa `passed` | `released` (or `handed-off`/`aborted`) |
 
 Because the artifacts carry the state, the loop is **resumable**: any later
 session (or `/spark`) reads the statuses and continues at the first gate

--- a/skills/go-live/SKILL.md
+++ b/skills/go-live/SKILL.md
@@ -26,8 +26,11 @@ Optional argument: the feature name. Resolve as usual.
    is no "just this once". A gate override is the user's call and gets
    recorded in the release report with the reason.
 2. **Delegate to the Release Manager — prepare only.** Invoke the
-   `release-manager` agent with the feature paths and the template from
-   `${CLAUDE_PLUGIN_ROOT}/templates/release-notes.md`. First pass: fresh
+   `release-manager` agent with the feature paths, the template from
+   `${CLAUDE_PLUGIN_ROOT}/templates/release-notes.md`, and `.spark/constitution.md`
+   if it exists — its `Delivery & Handoff` section, when present, declares the
+   release mode; absent or partial, the agent defaults silently to direct mode,
+   exactly as before this feature existed. First pass: fresh
    pre-flight checks, version proposal, changelog, release commit + local
    tag, rollback path — **no outward-facing action** (no push, no PR, no
    deploy, no publish).

--- a/skills/next-steps/SKILL.md
+++ b/skills/next-steps/SKILL.md
@@ -33,7 +33,7 @@ steer, not a fixed answer.
    - Every `.spark/<feature-name>/` directory: read `spec.md`, `plan.md`,
      `review.md`, `qa.md` where present and note each feature's status field
      (`draft`/`approved`, task completion, `passed`/`failed`, `released`).
-     Classify each feature as **shipped** (released), **in-flight** (mid-loop,
+     Classify each feature as **shipped** (released), **shipped-pending-approval** (`handed-off` — closed for this team, never resumed), **in-flight** (mid-loop,
      no open blocking findings), or **stalled** (open review/QA findings, or
      untouched for a while).
    - Any *unresolved* findings sitting in the newest `review.md` or `qa.md` —
@@ -70,8 +70,7 @@ steer, not a fixed answer.
   recommendation in conversation, not an artifact.
 - Never treat the agent's proposal as chosen. It is a suggestion until the
   user says which one (or their own idea) to run with.
-- If every existing feature is `released` and nothing is stalled, say that
-  explicitly before proposing something new — a clean state is worth naming,
+- If every existing feature is `released` or `handed-off` and nothing is stalled, say that explicitly before proposing something new — a clean state is worth naming,
   not skipped past.
 - If a stalled feature (open review/QA findings, or a plan sitting unbuilt)
   exists, the agent must weigh *finishing it* against *starting something

--- a/skills/spark/SKILL.md
+++ b/skills/spark/SKILL.md
@@ -47,8 +47,9 @@ spends them in the context the rest of the loop still has to fit into.
 | `plan.md` `approved`, tasks not all `done` | `/increment` |
 | tasks `done`, `review.md` missing or not `passed` | `/peer-review` |
 | `review.md` `passed`, `qa.md` missing or not `passed` | `/demo-day` |
-| `review.md` + `qa.md` `passed`, no `released` release | `/go-live` |
+| `review.md` + `qa.md` `passed`, no `released`/`handed-off` release | `/go-live` |
 | release `released` | loop closed — tell the user |
+| release `handed-off` | loop closed for this team — tell the user it's handed off, not yet approved elsewhere |
 
 ## How You Conduct
 

--- a/templates/constitution.md
+++ b/templates/constitution.md
@@ -84,6 +84,18 @@
 - e.g. User data is never logged in plaintext.
 - e.g. We never ship a Must story with a failing acceptance criterion.
 
+## 7. Delivery & Handoff
+
+<!-- How this project's Keep phase ends. Every field defaults to today's behavior when absent — an
+     undeclared project sees no new prompt, no new terminology, anywhere in /go-live. Declare this
+     only if release actually depends on someone outside the team approving a PR. -->
+
+- **Release mode:** `direct` \| `pr`. Default when absent: `direct`.
+- **Approver:** e.g. `CODEOWNERS`, a named reviewer, or a role — who merges when mode is `pr`. Default when absent: n/a (mode is `direct`).
+- **Target branch:** e.g. `main` — the branch a `pr`-mode release targets. Default when absent: n/a (mode is `direct`).
+- **Ticket-reference format:** e.g. `PROJ-123`, `#123`, a URL, or `none`. Default when absent: `none`.
+- **Terminal status:** the status a `pr`-mode release ends in once handed over — `handed-off`, unless amended. Default when absent: `released` (direct mode's only terminal status).
+
 ---
 
 ## Amendments

--- a/templates/release-notes.md
+++ b/templates/release-notes.md
@@ -5,7 +5,7 @@
 | **Phase** | Keep |
 | **Owner** | Release Manager (`/go-live`) |
 | **Input** | `review.md` (`passed`), `qa.md` (`passed`) |
-| **Status** | `preparing` \| `released` \| `aborted` |
+| **Status** | `preparing` \| `released` \| `aborted` \| `handed-off` |
 | **Version** | vX.Y.Z |
 | **Date** | YYYY-MM-DD |
 
@@ -36,6 +36,10 @@
 
 <!-- What was actually executed, with results. -->
 
+<!-- Direct mode: fill all four. Declared `pr` mode (handed-off): Version bump is
+     *proposed only*, no tag before merge; Deploy and Post-release smoke check
+     are N/A — write "N/A — handed-off, no deploy" rather than leaving them blank. -->
+
 | Action | Result |
 |---|---|
 | Version bump & tag | |
@@ -59,6 +63,10 @@
 
 - [ ] All pre-flight checks passed at release time
 - [ ] Changelog written in user-facing language
-- [ ] Release actions executed and verified (or `aborted` with reason)
+- [ ] Release actions executed and verified (or `aborted` with reason) —
+      in declared `pr` mode: PR open on the target branch, CI green, the
+      declared approver requested, the ticket linked where one is declared,
+      rollback path written; Deploy and Post-release smoke check are N/A
 - [ ] Learnings recorded
-- [ ] Status set to `released`
+- [ ] Status set to `released`, or `handed-off` in declared `pr` mode —
+      naming in one line what remains outstanding and who owns it

--- a/templates/spec.md
+++ b/templates/spec.md
@@ -6,6 +6,7 @@
 | **Owner** | Product Owner (`/story-time`), Designer (`/look-and-feel`) |
 | **Status** | `draft` \| `design-checked` \| `approved` \| `rejected` |
 | **Date** | YYYY-MM-DD |
+| **Ticket** | the constitution's declared format (e.g. `PROJ-123`, `#123`, a URL), or `none` |
 
 <!-- Budget: ~250 lines. This is a working document that four later phases re-read, not a design
      essay — every line here is paid for again in Plan, Act, Review and QA. If a section can't fit,


### PR DESCRIPTION
## Summary
- Adds a standing `Delivery & Handoff` declaration to the constitution
  (direct vs. PR, approver, target branch, ticket format, terminal
  status) — declared once, read by every release, never guessed.
- Adds `handed-off` as a second, honest terminal release status for
  projects delivering via PR: the loop ends there once a PR is open, CI
  is green (or N/A, as here) and the declared approver is requested —
  never on a deploy that didn't happen.
- Teaches `/spark` and `/next-steps` to treat `handed-off` as
  closed-for-this-team, distinct from `released`.
- Adds a `Ticket` row to `spec.md` so a project's ticket reference has
  exactly one home.
- Also includes the constitution's own §7 "Delivery & Handoff" amendment
  as a committed change on this branch (previously only in the working
  tree) — it is what makes this PR's own `handed-off` mechanism reachable
  in the first place, so it travels with this PR rather than as a
  separate concern.
- Purely additive: no protected template row/heading/column renamed or
  removed (constitution §3); zero difference for any project that
  declares nothing (verified live, `qa.md`).

**This PR is its own dogfood.** It is opened, self-reviewed and
self-merged under the very `pr`-mode declaration it introduces
(constitution §7, confirmed by the user 2026-08-06) — this repo's first
real exercise of `handed-off`.

## Test plan
- [x] `.spark/tracker-handoff/{spec,plan,review,qa,evidence}.md` — review `passed`, QA `passed` (one user-recorded override on AC-3.4, named follow-up B2)
- [x] `claude plugin validate .` green before and after the version bump

Ticket: none (this repo declares no tracker, constitution §7).