### PR TITLE
docs: add contributing guide and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug report
+description: A ceremony, gate or agent behaves differently than documented.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        aSPARK is prompt material, so "a bug" usually means an agent did something
+        the skill told it not to, or a gate let something through it should have
+        stopped. **A transcript excerpt is worth more than a description** — paste
+        what actually happened.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did the agent or gate do?
+      placeholder: /go-live created a tag even though qa.md still listed an open blocker.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+      description: If it contradicts something documented, link it (README, docs/workflow.md, a SKILL.md).
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: How to reproduce
+      description: The commands you ran, in order, and the state of `.spark/` when you ran them.
+      placeholder: |
+        1. /story-time add a settings page
+        2. /sprint-plan
+        3. /increment  — stopped after task 3
+        4. /go-live    — expected it to refuse
+    validations:
+      required: true
+
+  - type: textarea
+    id: transcript
+    attributes:
+      label: Transcript excerpt
+      description: The relevant part of the conversation, or the artifact that shows the problem. Redact anything private — this repo is public.
+      render: text
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which part
+      multiple: true
+      options:
+        - A skill / slash command
+        - An agent's behaviour
+        - A gate letting something through (or blocking wrongly)
+        - A template or artifact structure
+        - A lens
+        - Installation / plugin loading
+        - Docs contradict the behaviour
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: aSPARK version
+      description: From `.claude-plugin/plugin.json`, or "local clone" plus the commit you're on.
+      placeholder: "0.5.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: project-context
+    attributes:
+      label: The project you ran it on
+      description: Type (website / web-app / api / cli / library), and whether it has a `.spark/constitution.md`. Lens behaviour depends on both.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: How the loop works
+    url: https://github.com/a-lottes/aSPARK/blob/main/docs/workflow.md
+    about: The phases, gates, artifact chain and hand-over rules — read this before proposing a change to the loop.
+  - name: How to contribute
+    url: https://github.com/a-lottes/aSPARK/blob/main/CONTRIBUTING.md
+    about: What a good PR looks like here, and how to verify a change in a repo with no test suite.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,65 @@
+name: Enhancement
+description: An idea for the loop, a skill, an agent or the docs.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        aSPARK's design bias is **fewer, sharper ceremonies over more coverage**. A proposal
+        that adds a step has to earn it against the attention it costs every user of every
+        project. Making the case is the point of this form — not bureaucracy.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's the problem?
+      description: The situation where the loop falls short today. Concrete beats abstract — a run where this bit you is ideal.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you change?
+      description: Which skill, agent, template or lens, and how.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: What does it touch?
+      description: |
+        This decides how much process the change needs — see *Two contribution paths* in CONTRIBUTING.md.
+      options:
+        - A lens or docs only (scoped)
+        - An existing skill or agent's behaviour
+        - Gate behaviour or phase hand-over
+        - A template structure
+        - A new skill or agent
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What did you consider and reject?
+      description: Especially — could this be a lens, or a note in an existing skill, instead of new machinery?
+
+  - type: textarea
+    id: breaking
+    attributes:
+      label: Does it break anyone?
+      description: |
+        People have aSPARK installed and running. Renaming a slash command, or a protected
+        template heading, column or ID pattern (§3 of `.spark/constitution.md`) is breaking
+        by definition. Say so if it applies — it doesn't disqualify the idea, it just changes
+        how it ships.
+
+  - type: checkboxes
+    id: willing
+    attributes:
+      label: Would you like to build it?
+      options:
+        - label: I'd like to open the PR myself

--- a/.github/ISSUE_TEMPLATE/field_report.yml
+++ b/.github/ISSUE_TEMPLATE/field_report.yml
@@ -1,0 +1,91 @@
+name: Field report
+description: You ran aSPARK on a real project — tell us how it went.
+labels: ["documentation", "help wanted"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **This is the most useful thing you can send us.** aSPARK's Project Status has exactly
+        one unchecked box: the loop has never been proven end to end on someone else's real
+        project. A report where things went badly is *more* valuable than one where they went
+        well — nobody learns anything from "it worked".
+
+        Nothing here is a support request. Write as much or as little as you have.
+
+  - type: dropdown
+    id: project-type
+    attributes:
+      label: What kind of project?
+      options:
+        - website
+        - web-app
+        - api
+        - cli
+        - library
+        - something else / a mix
+    validations:
+      required: true
+
+  - type: dropdown
+    id: phases
+    attributes:
+      label: How far did you get?
+      multiple: true
+      options:
+        - /charter
+        - /next-steps
+        - /story-time
+        - /look-and-feel
+        - /sprint-plan
+        - /increment
+        - /peer-review
+        - /demo-day
+        - /go-live
+        - /spark (full loop)
+    validations:
+      required: true
+
+  - type: textarea
+    id: worked
+    attributes:
+      label: What worked?
+      description: Anything a gate caught that you'd otherwise have shipped is especially worth naming.
+    validations:
+      required: true
+
+  - type: textarea
+    id: friction
+    attributes:
+      label: Where did it get in the way?
+      description: |
+        Be blunt. Ceremonies that felt like overhead, questions that missed the point, a gate
+        that blocked for the wrong reason, a phase you skipped — and why.
+    validations:
+      required: true
+
+  - type: textarea
+    id: lenses
+    attributes:
+      label: Did a lens fire — and was it right?
+      description: |
+        Which lenses your constitution activated, whether their checks actually showed up in
+        the phases, and whether any fired where it didn't belong. **A lens that fired where it
+        shouldn't have is a defect** — suppression is a feature here.
+
+  - type: textarea
+    id: abandoned
+    attributes:
+      label: Did you stop using it? Where, and why?
+      description: If you dropped out mid-loop, that's the single most informative thing in this form.
+
+  - type: input
+    id: version
+    attributes:
+      label: aSPARK version
+      placeholder: "0.5.0"
+
+  - type: input
+    id: link
+    attributes:
+      label: Link to the project or its `.spark/` directory
+      description: Optional, and only if it's public. Never link anything you can't share.

--- a/.github/ISSUE_TEMPLATE/new_lens.yml
+++ b/.github/ISSUE_TEMPLATE/new_lens.yml
@@ -1,0 +1,87 @@
+name: Propose a lens
+description: A concern that matters for some kinds of project but not all.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A **lens** is a checklist the existing agents pick up when — and only when —
+        the project's profile says the concern applies. Lenses are knowledge, not
+        roles: they add no team member and no ceremony, and a new one is a new file
+        rather than an edit to any agent.
+
+        Read [`lenses/README.md`](https://github.com/a-lottes/aSPARK/blob/main/lenses/README.md)
+        and the *Adding a lens* section of
+        [CONTRIBUTING.md](https://github.com/a-lottes/aSPARK/blob/main/CONTRIBUTING.md)
+        first. **The hardest question is question 3 — please don't skip it.**
+
+  - type: input
+    id: name
+    attributes:
+      label: Lens name
+      description: Lowercase, one word if possible — it becomes `lenses/<name>.md`.
+      placeholder: performance
+    validations:
+      required: true
+
+  - type: textarea
+    id: concern
+    attributes:
+      label: What concern does it cover, and why isn't it already covered?
+      description: Name what a generic code review or the existing agents miss today.
+    validations:
+      required: true
+
+  - type: textarea
+    id: activation
+    attributes:
+      label: What switches it on?
+      description: |
+        A project **type** (`website`, `web-app`, `api`, `cli`, `library`), a **characteristic**
+        (`handles-auth`, `handles-pii`, `is-public`, `has-database`, `is-multilingual`), or both.
+      placeholder: "applies-to: [website, web-app] — anything with a rendered frontend."
+    validations:
+      required: true
+
+  - type: textarea
+    id: suppression
+    attributes:
+      label: Where does it stay silent?
+      description: |
+        **Suppression is a feature.** A check that fires where it doesn't apply teaches users
+        and agents to skim, which erodes trust in every other check. Name the profiles where
+        this lens must not fire, and say so concretely.
+      placeholder: "Off for `library` and `cli` — no render path, no user-perceived latency to measure."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: phases
+    attributes:
+      label: Which phases own its checks?
+      multiple: true
+      options:
+        - Specify (Product Owner — becomes ACs / NFRs)
+        - Specify (Designer — design review)
+        - Plan (Engineering Manager — architecture)
+        - Review (Reviewer — traced in the diff)
+        - Review (QA Tester — verified in the browser)
+    validations:
+      required: true
+
+  - type: textarea
+    id: checks
+    attributes:
+      label: Three example checks
+      description: |
+        Falsifiable ones. "Consider performance" is not a check; "no render-blocking resource
+        above 50 KB on the critical path" is. Three is enough to judge the proposal.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: willing
+    attributes:
+      label: Would you like to write it?
+      options:
+        - label: I'd like to open the PR for this lens myself

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+<!-- Thanks for contributing. Delete any section that genuinely doesn't apply. -->
+
+## What and why
+
+<!-- What changes, and what problem it solves. -->
+
+Closes #
+
+## Which path
+
+<!-- See "Two contribution paths" in CONTRIBUTING.md. -->
+
+- [ ] **Path A** — scoped change (a lens, docs, a fix in one file). No `.spark/` artifacts needed.
+- [ ] **Path B** — a change to the loop (new skill or agent, gate behaviour, templates, phase hand-over). `.spark/<feature>/` is committed with this PR.
+
+## How I verified it
+
+<!-- Required. This repo has no test suite, so this section IS the evidence.
+     What did you run, what came out, what did you expect? -->
+
+- [ ] `claude plugin validate .` passes
+- [ ] I exercised the affected phases against a real or scratch project — result below
+
+<!-- If this adds an optional capability: the negative case runs first. In a project
+     where the new thing is absent, nothing may change — no error, no warning, no mention. -->
+
+## Checks
+
+- [ ] English throughout — docs, skills, agents, templates and any `.spark/` artifacts
+- [ ] No protected template heading, column or ID pattern renamed or removed (§3 of `.spark/constitution.md`) — appending a column is fine
+- [ ] No slash command renamed or removed
+- [ ] No new dependency on a package, tool or sibling repo
+- [ ] Plugin-internal paths use `${CLAUDE_PLUGIN_ROOT}/…`, never relative
+- [ ] IDs (`US-` / `AC-` / `NFR-` / `T` / `F`) appended, never renumbered
+- [ ] README updated in this PR if it adds or changes a capability
+- [ ] Nothing private committed — `.spark/` is tracked and public
+
+## Breaking change?
+
+<!-- If yes: what breaks for someone who already has aSPARK installed?
+     Leave the version alone — the maintainer sets it at release. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,184 @@
+# Contributing to aSPARK
+
+Thanks for being here. aSPARK is a small project with a specific shape, and the
+few things that are unusual about it are worth knowing before you write a line.
+
+**This repo has no code.** It ships Markdown prompt material plus two JSON
+manifests — no runtime, no build step, no dependencies, no test suite. That single
+fact drives most of what follows: there is nothing to `npm install`, nothing to
+run green, and *verification has to be done by hand and written down.*
+
+**aSPARK is built with aSPARK.** The loop in the README is the loop this repo
+uses on itself. You do not always have to run it (see below), but it explains why
+the repo is full of `.spark/` directories.
+
+---
+
+## Ways to contribute
+
+| | Where to start |
+|---|---|
+| Something behaves wrong | [Open a bug report](../../issues/new?template=bug_report.yml) |
+| Add a lens for a concern aSPARK doesn't cover | [Propose a lens](../../issues/new?template=new_lens.yml) — and read *[Adding a lens](#adding-a-lens)* |
+| An idea for the loop, a skill or an agent | [Open an enhancement](../../issues/new?template=enhancement.yml) |
+| You ran aSPARK on a real project | [File a field report](../../issues/new?template=field_report.yml) — **the most valuable thing you can send us right now** |
+| Docs are wrong or unclear | A PR straight away is fine |
+
+Look for [`good first issue`](../../issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+if you want something scoped and ready to go.
+
+> **Field reports really are the gap.** The README's Project Status has exactly one
+> unchecked box: the lens layer has never been proven by a full loop run on someone
+> else's real project. A report saying "I ran this on my API and here's where it got
+> annoying" is worth more to aSPARK than most patches.
+
+**Before you start on something sizeable,** comment on the issue (or open one).
+Not for permission — so two people don't build the same thing, and so a design
+disagreement surfaces before you've written it.
+
+---
+
+## Two contribution paths
+
+How much process your change needs depends on what it touches.
+
+### Path A — a scoped change
+
+A lens, a docs fix, a wording correction, a bug fix inside one file.
+
+**No `.spark/` artifacts required.** Open a normal PR. It must state:
+
+- what you changed and **why**
+- **how you verified it** — see below
+
+### Path B — a change to the loop itself
+
+A new skill or agent, a change to gate behaviour, anything touching `templates/`,
+or a change to how phases hand over to each other.
+
+**Run the loop on it and ship the artifacts.** Commit `.spark/<your-feature>/`
+alongside the change: `spec.md`, `plan.md`, `review.md`, `qa.md`, `evidence.md`.
+[PR #3](https://github.com/a-lottes/aSPARK/pull/3) is the reference shape.
+
+This isn't ceremony for its own sake — the project constitution requires it:
+
+> *A change to the loop is validated by running the loop.*
+
+If you're unsure which path applies, ask in the issue. Guessing A when it's B just
+means we'll ask for the artifacts in review; nothing is lost.
+
+---
+
+## How to verify a change
+
+There are no tests to run. The bar, from the constitution, is two things:
+
+**1. The plugin still validates.**
+
+```bash
+claude plugin validate .
+```
+
+**2. You exercised the change and wrote down what happened.**
+
+Install your working copy and actually use the affected commands:
+
+```bash
+git clone https://github.com/a-lottes/aSPARK.git
+claude --plugin-dir /path/to/aSPARK
+```
+
+Then run the phases you touched, on a real project or a scratch one, and put the
+result in the PR — what you ran, what came out, what you expected.
+
+**If your change adds an optional capability, run the negative case first.** In a
+project where the new thing is *absent*, nothing may change: no error, no warning,
+no mention. That's a non-negotiable, and it's the case most likely to be broken by
+a well-meaning patch.
+
+> "It reads correctly" is not verification. Prompt material fails in ways that only
+> show up when an agent actually runs it.
+
+---
+
+## Adding a lens
+
+The most self-contained way to contribute, and the reason `lenses/` exists as a
+directory: **a new concern is a new file, never an edit to the agents.** Skills
+pass lens paths generically, so a lens plugs in without rewriting anyone's role.
+
+Copy [`lenses/cli.md`](lenses/cli.md) as your model. A lens needs:
+
+1. **Frontmatter** — `name`, `applies-to` (the project types or characteristics
+   that switch it on), `phases` (which SPARK phases own its checks).
+2. **An activation statement** — and, just as importantly, **where it stays
+   silent.** From the constitution: *suppression is a feature.* A check that fires
+   where it doesn't apply teaches users to skim, which erodes trust in every other
+   check. A lens that can't name where it's off isn't ready.
+3. **A "Who owns what" table** — each area mapped to a phase and the agent who
+   runs it. If a phase has no role here, say so explicitly and why (see the "No QA
+   row" note in the CLI lens).
+4. **The checklist** — every item tagged with its owning phase, every item
+   falsifiable. "Consider performance" is not a check; "no render-blocking
+   resource above 50 KB on the critical path" is.
+5. **Phase notes** — what the PO should turn into ACs/NFRs, what the Reviewer
+   should trace in the diff.
+
+Then wire it up: add the lens to the activation table in
+[`lenses/README.md`](lenses/README.md) and to the lens list in `README.md`.
+Docs ship in the same change as the capability.
+
+A lens **flags concerns and proposes NFRs. It never invents scope.**
+
+---
+
+## Things that will get a PR sent back
+
+Not style nits — these are load-bearing.
+
+- **Renaming or removing a protected template structure.** A sibling repo parses
+  artifacts shaped by `templates/` and there is *no version handshake*, so a rename
+  is a silent breaking change in someone else's tool. The protected headings,
+  columns and ID patterns are listed in §3 of
+  [`.spark/constitution.md`](.spark/constitution.md). **Appending a column is
+  fine**; renaming one is not.
+- **Renaming or removing a slash command.** Same reason — people have it installed.
+- **A hard dependency on anything.** No npm, no Python, no sibling repo, no
+  external tool. aSPARK installs into arbitrary projects that have none of it. An
+  optional integration must degrade to *silence*, never to an error.
+- **Relative plugin paths.** Always `${CLAUDE_PLUGIN_ROOT}/…`.
+- **Renumbering IDs.** `US-` / `AC-` / `NFR-` / `T` / `F` identifiers are permanent
+  and append-only. Breaking a downstream citation is a defect, not a cosmetic issue.
+- **Anything but English.** Everything committed is English without exception —
+  docs, skills, agents, templates and `.spark/` artifacts — whatever language the
+  conversation happened in.
+- **Anything private.** `.spark/` is tracked in this repo, so everything under it
+  is published. No secrets, no credentials, no customer material, anywhere.
+- **A capability without its README entry.** Docs ship in the same PR.
+
+---
+
+## Commits, branches, PRs
+
+- **[Conventional Commits](https://www.conventionalcommits.org/)** — `feat:`,
+  `fix:`, `docs:`, `chore:`.
+- **One branch per change, prefixed with its type** — `feat/performance-lens`,
+  `docs/fix-install-steps`.
+- **PRs go into `main`.** This repo delivers by pull request, never by direct push
+  — that applies to the maintainer too.
+- **Don't bump the version.** `.claude-plugin/plugin.json` holds the single version
+  and the maintainer sets it at release time.
+- Link the issue your PR closes (`Closes #7`).
+
+Small PRs get reviewed fast. A PR that changes one thing and explains how it was
+verified is close to unrejectable.
+
+---
+
+## Questions
+
+Open an issue with the `question` label, or ask on the issue you're working from.
+If something in this document is wrong or unclear, that's a docs bug — file it.
+
+By contributing you agree that your work is licensed under the
+[MIT License](LICENSE), like the rest of the project.


### PR DESCRIPTION
## What and why

The repo has `good first issue` labels and eight open issues, but no `CONTRIBUTING.md`, no issue templates and no PR template. A newcomer had nothing telling them how to set up, what a good PR looks like here, or — the unusual part — that aSPARK develops itself with aSPARK.

This adds the community-health layer, shaped around the two things that make this repo different from a normal one: **there is no test suite**, and **the loop is the product**.

### The tiered PR policy

The constitution says *"A change to the loop is validated by running the loop."* Applied literally to outside contributors, that would ask someone fixing a typo in a lens to run five phases — which would make the `good first issue` labels decorative.

So `CONTRIBUTING.md` declares two paths:

- **Path A — scoped change** (a lens, docs, a fix in one file): no `.spark/` artifacts, but a mandatory *how I verified it* section.
- **Path B — a change to the loop** (new skill or agent, gate behaviour, templates, phase hand-over): the full artifact chain, with PR #3 as the reference shape.

### The issue forms

Five of them, two of which are deliberately not generic:

- **Propose a lens** makes *"where does it stay silent?"* a required field. Suppression is a constitution principle, and a lens that can't name where it's off isn't ready. Directly serves #6 and #7.
- **Field report** exists because the README's Project Status has exactly one unchecked box — the lens layer has never been proven by a full loop run on someone else's real project. This is the form that closes it.

All five forms reference only labels that already exist in the repo.

Related: #4, #5, #6, #7

## Which path

- [x] **Path A** — scoped change (docs only). No `.spark/` artifacts needed.
- [ ] **Path B** — a change to the loop.

Path A because nothing here touches a skill, agent, template, gate or lens. No behaviour of the loop changes; `claude plugin validate` sees the same plugin before and after.

## How I verified it

- [x] `claude plugin validate .` passes — with one pre-existing warning (`autoUpdate` in `marketplace.json`) that is unrelated to this change and present on `main` too.
- [x] All five issue forms parse as valid YAML, with no duplicate field ids, no dropdown without options, and every non-markdown block carrying an id and a label.
- [x] Every label referenced by a form (`bug`, `enhancement`, `documentation`, `help wanted`) already exists in the repo — a form referencing a missing label fails silently on GitHub.
- [x] This PR is itself the first run of the new PR template.

Not verified: how the forms actually render in GitHub's issue UI. That can only be checked after merge, since GitHub reads issue forms from the default branch. Worth a look at `/issues/new/choose` once this lands.

## Checks

- [x] English throughout
- [x] No protected template heading, column or ID pattern renamed or removed — no template touched
- [x] No slash command renamed or removed
- [x] No new dependency on a package, tool or sibling repo
- [x] Plugin-internal paths use `${CLAUDE_PLUGIN_ROOT}/…`, never relative — n/a, no skill or agent touched
- [x] IDs appended, never renumbered — n/a
- [x] README updated in this PR if it adds or changes a capability — n/a, no capability change
- [x] Nothing private committed

## Breaking change?

No. Docs and repo metadata only; nothing an installed consumer loads. Version deliberately left alone.

## Open questions for review

1. **A dedicated `field-report` label?** The form currently carries `documentation` + `help wanted` to match the precedent set by #4 and #5, but a field report isn't documentation. A `field-report` label would make these filterable — it needs creating first, so it's not in this PR.
2. **Is `new_lens.yml` too strict?** Six of seven fields are required. That's intentional, but it is real friction on a small project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
