### PR TITLE
chore: use the lottes.dev author email in the manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
   "autoUpdate": true,
   "owner": {
     "name": "Andreas Lottes",
-    "email": "andreas.lottes@adesso.de"
+    "email": "andreas@lottes.dev"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "version": "0.5.0",
   "author": {
     "name": "Andreas Lottes",
-    "email": "andreas.lottes@adesso.de"
+    "email": "andreas@lottes.dev"
   },
   "keywords": ["agile", "scrum", "team", "workflow", "sdlc", "quality-gates", "spec-driven-development"]
 }


### PR DESCRIPTION
## What and why

Both `.claude-plugin/plugin.json` (`author.email`) and `.claude-plugin/marketplace.json` (`owner.email`) carried `andreas.lottes@adesso.de`, the adesso work address. This points both at `andreas@lottes.dev` — the address this project is actually maintained under, and already the git author on every commit here.

Metadata only: no version bump, no behaviour change, no user-visible surface touched.

Noted for the record: `v0.5.0` is already tagged and pushed, and that tag still carries the old address. Deliberately **not** repointing a published tag for a two-line metadata fix — this rides along in the next release instead.

## Which path

- [x] **Path A** — scoped change (a lens, docs, a fix in one file). No `.spark/` artifacts needed.
- [ ] **Path B** — a change to the loop (new skill or agent, gate behaviour, templates, phase hand-over). `.spark/<feature>/` is committed with this PR.

## How I verified it

- [x] `claude plugin validate .` passes

Run on this branch, with the change applied:

```
Validating marketplace manifest: .claude-plugin/marketplace.json

⚠ Found 1 warning:

  ❯ autoUpdate: Unknown field 'autoUpdate'. Claude Code ignores it at load time.

✔ Validation passed with warnings
```

That warning is **pre-existing and unrelated** — the identical output came from a clean checkout of `b477b68` (the base commit) before this change, so the diff introduces no new warning.

- [ ] I exercised the affected phases against a real or scratch project — **not applicable.** No phase, skill, agent or gate is touched; the two edited keys are contact metadata that no ceremony reads. There is no runtime behaviour to exercise.

## Checks

- [x] English throughout — docs, skills, agents, templates and any `.spark/` artifacts
- [x] No protected template heading, column or ID pattern renamed or removed (§3 of `.spark/constitution.md`) — no template touched
- [x] No slash command renamed or removed
- [x] No new dependency on a package, tool or sibling repo
- [x] Plugin-internal paths use `${CLAUDE_PLUGIN_ROOT}/…`, never relative — no paths touched
- [x] IDs (`US-` / `AC-` / `NFR-` / `T` / `F`) appended, never renumbered — none touched
- [x] README updated in this PR if it adds or changes a capability — n/a, no capability change
- [x] Nothing private committed — the new address is the maintainer's public contact, already the git author email throughout this repo

## Breaking change?

No. Contact metadata only; nothing an existing install depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)