### PR TITLE
chore: give field reports their own label

### DIFF
--- a/.github/ISSUE_TEMPLATE/field_report.yml
+++ b/.github/ISSUE_TEMPLATE/field_report.yml
@@ -1,6 +1,6 @@
 name: Field report
 description: You ran aSPARK on a real project — tell us how it went.
-labels: ["documentation", "help wanted"]
+labels: ["field-report"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## What and why

`field_report.yml` was carrying `documentation` + `help wanted`, inherited from the precedent #4 and #5 set before a dedicated label existed. Neither fits a submitted report: it isn't documentation, and it isn't help wanted — someone is *answering* the ask, not making one.

The `field-report` label (`#e68a00`) is now created and applied. The real gain is filterability: the README's single unchecked box is evidence from real outside projects, and that evidence only works as a set you can pull up in one query.

**#4 and #5 keep `help wanted`** — they are solicitations for reports, not reports — but trade `documentation` for `field-report`, so the ask and the answers land in the same filter.

## Which path

- [x] **Path A** — scoped change. One line in one issue template.
- [ ] **Path B** — a change to the loop.

## How I verified it

- [x] `field_report.yml` still parses as valid YAML, 8 fields intact
- [x] The `field-report` label exists in the repo — a form referencing a missing label fails silently on GitHub
- [x] Templates now live on `main`, so this renders on the next visit to `/issues/new/choose`

## Checks

- [x] English throughout
- [x] No protected template heading, column or ID pattern touched
- [x] No slash command renamed or removed
- [x] No new dependency
- [x] Nothing private committed

## Breaking change?

No. Repo metadata only.

---

Branched from `main` after #12 merged; independent of #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)