### PR TITLE
docs: move the Project Status evidence into docs/status.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,10 @@ the repo is full of `.spark/` directories.
 Look for [`good first issue`](../../issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 if you want something scoped and ready to go.
 
-> **Field reports really are the gap.** The README's Project Status has exactly one
-> unchecked box: the lens layer has never been proven by a full loop run on someone
-> else's real project. A report saying "I ran this on my API and here's where it got
-> annoying" is worth more to aSPARK than most patches.
+> **Field reports really are the gap.** [`docs/status.md`](docs/status.md) lists
+> exactly one thing as unproven: the lens layer has never been through a full loop
+> run on someone else's real project. A report saying "I ran this on my API and
+> here's where it got annoying" is worth more to aSPARK than most patches.
 
 **Before you start on something sizeable,** comment on the issue (or open one).
 Not for permission — so two people don't build the same thing, and so a design

--- a/README.md
+++ b/README.md
@@ -234,38 +234,28 @@ See [`tools/README.md`](tools/README.md) for how this works and how to add anoth
 
 ## Project Status
 
-aSPARK is feature-complete: the v0.1.0 loop has passed a full end-to-end dry run, and the spec-driven layer added on top (constitution, Clarify pass, NFRs, traceability) has been dry-run-validated through the Plan phase. The situational-lens layer (project profile with types + characteristics, eight lenses) is wired through every phase and was dogfooded through aSPARK's own `/story-time` — which caught two real design defects before they shipped. This README always reflects the current state.
+aSPARK is feature-complete — everything below ships today. The column that matters
+is **how well each part is proven**, because prompt material has no test suite: the
+only evidence is a documented run, written down. This section always reflects the
+current state.
 
-The optional-tools layer (`tools/`, wired into `/sprint-plan`, `/peer-review` and `/demo-day`) has now been dogfooded end to end against the *installed* plugin, across two QA rounds ([.spark/graph-gates/qa.md](.spark/graph-gates/qa.md)): the absent case by real ceremony invocations in a graph-less repo, and the available case by direct agent runs against an isolated graph-built scratch copy (the designated real-project venue was left untouched, since it has independent work in flight). **25 of 30 acceptance criteria pass live; zero remain unverified.** Every documented call form, return shape and failure mode was run against the tool itself, and the `files:` note format was validated by running the consuming parser.
-
-**Six criteria ship as a documented `partial`**, each for a specific, named reason rather than an open gap — this was an explicit, informed shipping decision, not an oversight:
-
-| Criterion | What is not (yet) proven, and why |
+| Area | State |
 |---|---|
-| AC-1.2 | Byte-identical output vs. the pre-change version — needs a direct 0.3.1-vs-0.4.0 artifact diff, one more full ceremony pair |
-| AC-2.2 | MCP-first precedence — no MCP server exists in any environment used so far to test against |
-| AC-2.3 | The installed-but-unbuilt hint firing exactly once, inside a live ceremony transcript (verified at the tool level, not yet caught mid-ceremony) |
-| AC-3.2 | The ceremony's own reaction to a stale graph (say once, then treat as absent) — the underlying `staleness` behaviour itself *is* verified live, twice |
-| AC-3.5 | `/demo-day`'s existing no-browser stop path — this project has no browser surface to re-prove it against, a pre-existing exception, not a new one |
-| AC-5.2 | Omitting a `files:` note for a genuinely unknowable-at-plan-time task — this feature's own plan has no such task to exercise the path on |
+| The loop — 10 skills, 7 agents, 6 templates, `/spark` | **Proven** — full end-to-end run on a sample app, all five gates enforced, shipped as `v0.1.0` |
+| Spec-driven core — constitution, Clarify pass, NFRs, traceability | **Proven through Plan** — live review/QA traceability awaits a full `/increment` |
+| Situational lenses (`lenses/`) | **Shipped, unproven in the field** — dogfooded on aSPARK itself, never yet run on someone else's project |
+| Optional tools (`tools/`, `aspark-graph`) | **25 of 30 criteria proven live**, six ship as a documented `partial` |
+| PR-mode delivery (`handed-off`) | **Proven** on this repo's own release ([PR #3](https://github.com/a-lottes/aSPARK/pull/3)) |
 
-All other wiring claims — the tool-file hand-over firing live, the QA slice scoping a real test plan via `story_trace`, a review citing concrete `file:line` evidence, an EM agent correctly classifying an empty `impact` result as "no declared link" rather than "nothing at risk" — are now proven by a real run, not by a walkthrough.
+**The one real gap:** the lens layer's success signal is a UI-lens QA-verified on a
+real `website` **and** a Review-lens Review-verified on a real `api`. Neither has
+happened yet. Lens compliance is instruction-driven — no test enforces that a lens
+actually fired, and none can — so a report from a real project is the only evidence
+that counts. If you run aSPARK on yours, [#4](https://github.com/a-lottes/aSPARK/issues/4)
+and [#5](https://github.com/a-lottes/aSPARK/issues/5) are waiting for you.
 
-- [x] Repo scaffold, plugin manifest, license
-- [x] README with concept, team and usage guide
-- [x] Artifact templates (`templates/`) — constitution, spec, plan, review-report, qa-report, release-notes, each (bar the constitution) with its gate checklist
-- [x] The seven team agents (`agents/`) — facilitator, product-owner, designer, engineering-manager, reviewer, qa-tester, release-manager
-- [x] The ten ceremony skills (`skills/`) — charter, next-steps, story-time, look-and-feel, sprint-plan, increment, peer-review, demo-day, go-live, spark
-- [x] Spec-driven core — project constitution (`/charter`), Specify-phase Clarify pass, non-functional requirements, and `US-`/`AC-`/`NFR-` traceability from spec through plan, review and QA
-- [x] Situational lenses (`lenses/`) — the constitution profile detects project **type** (`website`, `web-app`, `api`, `cli`, `library`) and **characteristics** (auth, PII, public, database, multilingual), activating concern checklists — `seo`, `ux`, `api`, `cli`, `library`, `security`, `i18n`, `data` — that the existing agents apply in the phases they own; the constitution is the single source of truth (no constitution → a nudge, never an applied lens), 4+ active lenses flag elevated load, and new concerns are add-a-file, no agent rewrite
-- [x] Lens layer dogfooded through aSPARK's own loop — `/story-time` on the feature itself ([.spark/situational-lenses/spec.md](.spark/situational-lenses/spec.md)): the PO's Clarify pass caught two real defects in the first cut (per-phase fallback detection was over-built and drift-prone; no lens-load visibility), both fixed before commit
-- [ ] Success signal proven on real projects — the lens layer's own spec defines success as a UI-lens firing and being QA-verified on a `website` **and** a Review-lens firing and being Review-verified on an `api`, both under the same `NFR-n`. Not yet demonstrated by a full loop run on either. Standing caveat: lens compliance is instruction-driven — no test enforces that a lens actually fired
-- [x] `tracker-handoff`'s positive case — proven live on this repo's own release: the constitution declares PR-mode delivery, [PR #3](https://github.com/a-lottes/aSPARK/pull/3) was opened, self-reviewed and merged, and `.spark/tracker-handoff/release.md` reached status `handed-off` with no tag created before merge
-- [x] The `/spark` orchestrator — full loop with gate stops, resume support and feedback-loop escalation
-- [x] Workflow deep-dive ([docs/workflow.md](docs/workflow.md)) — constitution, artifact chain, gate invariants, traceability, feedback loops, role boundaries
-- [x] Plugin structure validated (`claude plugin validate` ✔, skill/agent naming consistent)
-- [x] End-to-end test on a sample project — full loop run on a vanilla-JS `quick-todo` app: PO→Designer→EM→build→review→real-browser QA→release, all five gates enforced, shipped as `v0.1.0`
-- [x] Spec-driven dry run on a sample project — `/charter`→`/story-time` (with Clarify pass)→`/look-and-feel`→`/sprint-plan` on a vanilla-JS `quicknote` app: constitution bound every phase, NFRs and `US-`/`AC-`/`NFR-` traceability flowed spec→plan with full Must-AC coverage, spec and plan gates enforced. Live review/QA traceability tables pending a full `/increment` build.
+Full evidence — every run, every `partial` and why it ships that way:
+**[docs/status.md](docs/status.md)**.
 
 ---
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,116 @@
+# Status & Evidence
+
+The README carries the summary. This file carries the proof.
+
+aSPARK ships Markdown prompt material — there is no test suite and none is
+possible, so the only evidence a capability works is a **documented run of the
+phases it touches**, negative case first. That is the project constitution's bar,
+and this file is where those runs are written down.
+
+Nothing here is aspirational. If something is unproven, it says so.
+
+---
+
+## The loop
+
+| | |
+|---|---|
+| **Scope** | 10 ceremony skills, 7 agents, 6 templates, the `/spark` orchestrator |
+| **Evidence** | Full end-to-end loop run on a vanilla-JS `quick-todo` app: PO → Designer → EM → build → review → real-browser QA → release. All five gates enforced. Shipped as `v0.1.0`. |
+| **State** | Proven |
+
+## Spec-driven core
+
+| | |
+|---|---|
+| **Scope** | Project constitution (`/charter`), Specify-phase Clarify pass, non-functional requirements, `US-` / `AC-` / `NFR-` traceability from spec through plan, review and QA |
+| **Evidence** | Dry run on a vanilla-JS `quicknote` app: `/charter` → `/story-time` (with Clarify pass) → `/look-and-feel` → `/sprint-plan`. The constitution bound every phase; NFRs and the ID chain flowed spec → plan with full Must-AC coverage; the spec and plan gates were enforced. |
+| **State** | Proven through the Plan phase. Live review/QA traceability tables still await a full `/increment` build. |
+
+## Situational lenses
+
+| | |
+|---|---|
+| **Scope** | `lenses/` — the constitution profile detects project **type** (`website`, `web-app`, `api`, `cli`, `library`) and **characteristics** (auth, PII, public, database, multilingual), activating concern checklists (`seo`, `ux`, `api`, `cli`, `library`, `security`, `i18n`, `data`) that the existing agents apply in the phases they own. The constitution is the single source of truth — no constitution means a nudge, never an applied lens. Four or more active lenses flag elevated load. A new concern is add-a-file; no agent is rewritten. |
+| **Evidence** | Dogfooded through aSPARK's own `/story-time` ([`.spark/situational-lenses/spec.md`](../.spark/situational-lenses/spec.md)). The PO's Clarify pass caught two real defects in the first cut — per-phase fallback detection was over-built and drift-prone, and lens load had no visibility — both fixed before commit. |
+| **State** | **Shipped, unproven in the field.** See *The open gap* below. |
+
+### The open gap
+
+The lens layer's own spec defines success as **a UI-lens firing and being
+QA-verified on a real `website`**, *and* **a Review-lens firing and being
+Review-verified on a real `api`** — both under the same `NFR-n`.
+
+Neither has been demonstrated by a full loop run on a real project.
+
+**Standing caveat:** lens compliance is instruction-driven. No test enforces that a
+lens actually fired, and none can. A field report from someone else's project is
+the only evidence that counts here — which is why it is the most valuable thing
+you can contribute right now.
+
+## Optional tools layer
+
+| | |
+|---|---|
+| **Scope** | `tools/`, wired into `/sprint-plan`, `/peer-review` and `/demo-day` |
+| **Evidence** | Dogfooded end to end against the *installed* plugin, across two QA rounds ([`.spark/graph-gates/qa.md`](../.spark/graph-gates/qa.md)): the **absent** case by real ceremony invocations in a graph-less repo, and the **available** case by direct agent runs against an isolated graph-built scratch copy. (The designated real-project venue was left untouched — it had independent work in flight.) |
+| **State** | **25 of 30 acceptance criteria pass live; zero remain unverified.** Six ship as a documented `partial`. |
+
+Every documented call form, return shape and failure mode was run against the tool
+itself, and the `files:` note format was validated by running the consuming parser.
+
+All other wiring claims are proven by a real run rather than a walkthrough: the
+tool-file hand-over firing live, the QA slice scoping a real test plan via
+`story_trace`, a review citing concrete `file:line` evidence, and an EM agent
+correctly classifying an empty `impact` result as "no declared link" rather than
+"nothing at risk".
+
+### The six `partial` criteria
+
+Each ships `partial` for a specific, named reason rather than as an open gap. This
+was an explicit, informed shipping decision, not an oversight.
+
+| Criterion | What is not (yet) proven, and why | Tracked as |
+|---|---|---|
+| AC-1.2 | Byte-identical output vs. the pre-change version — needs a direct 0.3.1-vs-0.4.0 artifact diff, one more full ceremony pair | — |
+| AC-2.2 | MCP-first precedence — no MCP server existed in any environment used for testing so far | [#8](https://github.com/a-lottes/aSPARK/issues/8) |
+| AC-2.3 | The installed-but-unbuilt hint firing exactly once inside a live ceremony transcript (verified at the tool level, not yet caught mid-ceremony) | [#11](https://github.com/a-lottes/aSPARK/issues/11) |
+| AC-3.2 | The ceremony's own reaction to a stale graph — say once, then treat as absent. The underlying `staleness` behaviour itself *is* verified live, twice | [#11](https://github.com/a-lottes/aSPARK/issues/11) |
+| AC-3.5 | `/demo-day`'s existing no-browser stop path — this project has no browser surface to re-prove it against. A pre-existing exception, not a new one | [#9](https://github.com/a-lottes/aSPARK/issues/9) |
+| AC-5.2 | Omitting a `files:` note for a genuinely unknowable-at-plan-time task — this feature's own plan has no such task to exercise the path on | — |
+
+## Delivery mode
+
+| | |
+|---|---|
+| **Scope** | PR-mode delivery with `handed-off` as the loop's terminal status |
+| **Evidence** | Proven live on this repo's own release: the constitution declares PR-mode delivery, [PR #3](https://github.com/a-lottes/aSPARK/pull/3) was opened, self-reviewed and merged, and `.spark/tracker-handoff/release.md` reached status `handed-off` with **no tag created before merge**. |
+| **State** | Proven |
+
+## Browser backends for `/demo-day`
+
+| | |
+|---|---|
+| **Scope** | Claude in Chrome, Playwright MCP, Chrome DevTools MCP |
+| **Evidence** | Only **Claude in Chrome** has been used in a real QA run. |
+| **State** | The other two are documented but unproven — tracked as [#10](https://github.com/a-lottes/aSPARK/issues/10). |
+
+---
+
+## Build checklist
+
+- [x] Repo scaffold, plugin manifest, license
+- [x] README with concept, team and usage guide
+- [x] Artifact templates (`templates/`) — constitution, spec, plan, review-report, qa-report, release-notes, each (bar the constitution) with its gate checklist
+- [x] The seven team agents (`agents/`) — facilitator, product-owner, designer, engineering-manager, reviewer, qa-tester, release-manager
+- [x] The ten ceremony skills (`skills/`) — charter, next-steps, story-time, look-and-feel, sprint-plan, increment, peer-review, demo-day, go-live, spark
+- [x] Spec-driven core — constitution, Clarify pass, NFRs, `US-`/`AC-`/`NFR-` traceability
+- [x] Situational lenses (`lenses/`), dogfooded through aSPARK's own loop
+- [x] The `/spark` orchestrator — full loop with gate stops, resume support and feedback-loop escalation
+- [x] Optional tools layer (`tools/`) — dogfooded against the installed plugin
+- [x] Workflow deep-dive ([`workflow.md`](workflow.md)) — constitution, artifact chain, gate invariants, traceability, feedback loops, role boundaries
+- [x] Plugin structure validated (`claude plugin validate` ✔, skill/agent naming consistent)
+- [x] End-to-end test on a sample project (`quick-todo`)
+- [x] Spec-driven dry run on a sample project (`quicknote`)
+- [x] `tracker-handoff`'s positive case proven on this repo's own release
+- [ ] **Success signal proven on real projects** — see *The open gap* above


### PR DESCRIPTION
## What and why

`README.md`'s *Project Status* had grown into 34 lines of internal QA notes: two
dense evidence paragraphs, a six-row table of `partial` acceptance criteria, and a
15-item build checklist. All of it true and worth keeping — but it sat in the
document a first-time visitor reads, where it lands as a wall rather than as
confidence.

This moves the full evidence into a new `docs/status.md` and leaves the README with
a five-row summary table, the one real gap stated plainly, and a link.

The constitution's bar for this section is that it *"states what is proven and what
is not"*. The summary still does, per area — the detail is one click away rather
than deleted. Nothing was softened: "shipped, unproven in the field" is still the
label on the lens layer.

Two things the move earns beyond brevity:

- the six `partial` criteria now link to the issues tracking them (#8, #9, #10, #11)
- the open lens-layer gap points at #4 and #5, so the section that admits the
  weakness is also the one that invites the fix

Also fixes `CONTRIBUTING.md`, which promised *"exactly one unchecked box"* in a
README section that no longer has checkboxes.

## Which path

- [x] **Path A** — scoped change (a lens, docs, a fix in one file). No `.spark/` artifacts needed.
- [ ] **Path B** — a change to the loop.

Docs only. No skill, agent, template or manifest is touched.

## How I verified it

- [x] `claude plugin validate .` passes

```
✔ Validation passed with warnings
  ⚠ autoUpdate: Unknown field 'autoUpdate'. Claude Code ignores it at load time.
```

The warning is **pre-existing and unrelated** — `autoUpdate` in
`.claude-plugin/marketplace.json` predates this branch and is untouched here.
Worth its own issue; not folded into a docs PR.

- [x] Every link in the moved content resolved by hand from its new location:
  `../.spark/situational-lenses/spec.md`, `../.spark/graph-gates/qa.md`,
  `workflow.md` and the README's `docs/status.md` target all exist.
- [x] Grepped the repo for other references to the removed content.
  `CONTRIBUTING.md:30` was the only live one and is fixed in this PR.

**Deliberately not changed:** the `.spark/` artifacts that cite old README line
numbers (`graph-gates/review.md`, `graph-gates/plan.md`,
`tracker-handoff/plan.md`, …). Those are frozen records of past review and QA
rounds; rewriting them to match today's README would falsify the trail.

No phase was exercised, because no phase behaviour changed.

## Checks

- [x] English throughout
- [x] No protected template heading, column or ID pattern renamed or removed — no template touched
- [x] No slash command renamed or removed
- [x] No new dependency on a package, tool or sibling repo
- [x] Plugin-internal paths use `${CLAUDE_PLUGIN_ROOT}/…` — none added
- [x] IDs appended, never renumbered — none touched
- [x] README updated in this PR — it *is* the change
- [x] Nothing private committed

## Breaking change?

No. Documentation only; no consumed contract is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
